### PR TITLE
Refactroing timer mechanism

### DIFF
--- a/nng/src/core/aio.c
+++ b/nng/src/core/aio.c
@@ -358,7 +358,6 @@ nni_aio_begin(nni_aio *aio)
 		aio->a_sleep     = false;
 		aio->a_expire_ok = false;
 		nni_mtx_unlock(&eq->eq_mtx);
-
 		nni_task_dispatch(&aio->a_task);
 		return (NNG_ECANCELED);
 	}


### PR DESCRIPTION
By replacing nni_timer_schedule with nni_sleep_aio, so that timer can be triggered concurrently.
However, it slows down the system's connection rate.