### PR TITLE
 * MDF [tcp] disable bump_tx/rx

### DIFF
--- a/nng/src/sp/protocol/reqrep0/nano_tcp.c
+++ b/nng/src/sp/protocol/reqrep0/nano_tcp.c
@@ -690,10 +690,10 @@ nano_pipe_recv_cb(void *arg)
 		return;
 	}
 	debug_msg("#########nano_pipe_recv_cb !############");
-
+	p->ka_refresh = 0;
 	msg = nni_aio_get_msg(&p->aio_recv);
 	if (msg == NULL) {
-		goto drop;
+		goto end;
 	}
 
 	header = nng_msg_header(msg);
@@ -703,7 +703,6 @@ nano_pipe_recv_cb(void *arg)
 	    nng_msg_header_len(msg));
 	// ttl = nni_atomic_get(&s->ttl);
 	nni_msg_set_pipe(msg, p->id);
-	p->ka_refresh = 0;
 	// TODO HOOK
 	switch (nng_msg_cmd_type(msg)) {
 	case CMD_SUBSCRIBE:
@@ -721,15 +720,13 @@ nano_pipe_recv_cb(void *arg)
 		break;
 	case CMD_PUBLISH:
 		// TODO QoS 1/2 sender side cache
-		break;
 	case CMD_DISCONNECT:
 	case CMD_UNSUBSCRIBE:
 		break;
 	case CMD_PUBREC:
 		// break;
-	case CMD_PINGREQ:
+	//case CMD_PINGREQ:
 	case CMD_PUBREL:
-		goto drop;
 	case CMD_PUBACK:
 	case CMD_PUBCOMP:
 		goto drop;
@@ -783,6 +780,7 @@ drop:
 	nni_pipe_recv(p->pipe, &p->aio_recv);
 	nni_msg_free(msg);
 	debug_msg("Warning:dropping msg");
+end:
 	return;
 }
 

--- a/nng/src/sp/transport/tcp/tcp.c
+++ b/nng/src/sp/transport/tcp/tcp.c
@@ -457,7 +457,7 @@ tcptran_pipe_send_cb(void *arg)
 
 	msg = nni_aio_get_msg(aio);
 	n   = nni_msg_len(msg);
-	nni_pipe_bump_tx(p->npipe, n);
+	//nni_pipe_bump_tx(p->npipe, n);
 	// free qos buffer
 	if (p->qlength > 16 + NNI_NANO_MAX_PACKET_SIZE) {
 		nng_free(p->qos_buf, p->qlength);
@@ -545,7 +545,7 @@ tcptran_pipe_recv_cb(void *arg)
 			nni_aio_set_iov(qsaio, 1, &iov);
 			p->cmd = CMD_PINGRESP;
 			nng_stream_send(p->conn, qsaio);
-			goto quit;
+			goto notify;
 		} else if ((p->rxlen[0] & 0XFF) == CMD_DISCONNECT) {
 		}
 	}
@@ -706,7 +706,7 @@ tcptran_pipe_recv_cb(void *arg)
 	nni_msg_set_payload_ptr(msg, payload_ptr);
 
 	// keep connection & Schedule next receive
-	nni_pipe_bump_rx(p->npipe, n);
+	//nni_pipe_bump_rx(p->npipe, n);
 	tcptran_pipe_recv_start(p);
 	nni_mtx_unlock(&p->mtx);
 
@@ -728,9 +728,15 @@ recv_error:
 	return;
 quit:
 	// nni_aio_list_remove(aio);
-	nni_pipe_bump_rx(p->npipe, n);
+	//nni_pipe_bump_rx(p->npipe, n);
 	tcptran_pipe_recv_start(p);
 	nni_mtx_unlock(&p->mtx);
+	return;
+notify:
+	//nni_pipe_bump_rx(p->npipe, n);
+	tcptran_pipe_recv_start(p);
+	nni_mtx_unlock(&p->mtx);
+	nni_aio_finish_error(aio, rv);
 	return;
 }
 


### PR DESCRIPTION
 * FIX [nano_tcp] PINGREQ resets keepalived timer counter. fix #91 