### PR TITLE
Add refcnt to connparam & Fix the conflict of conn_param

### DIFF
--- a/nanomq/apps/broker.c
+++ b/nanomq/apps/broker.c
@@ -102,7 +102,6 @@ server_cb(void *arg)
 		if (nng_msg_cmd_type(msg) == CMD_DISCONNECT) {
 			// Disconnect reserved for will msg.
 			if (conn_param_get_will_flag(work->cparam)) {
-				// pub last will msg TODO reuse same msg.
 				msg = nano_msg_composer(&msg,
 				    conn_param_get_will_retain(work->cparam),
 				    conn_param_get_will_qos(work->cparam),
@@ -165,7 +164,7 @@ server_cb(void *arg)
 			}
 			cparam = work->cparam;
 			work->cparam = NULL;
-			destroy_conn_param(cparam);
+			conn_param_free(cparam);
 		}
 		work->state = WAIT;
 		nng_aio_finish(work->aio, 0);
@@ -355,7 +354,6 @@ server_cb(void *arg)
 					work->pid.id = p_info.pipe;
 					nng_msg_set_pipe(work->msg, work->pid);
 					work->msg   = NULL;
-					work->state = SEND;
 					work->pipe_ct->current_index++;
 					nng_ctx_send(work->ctx, work->aio);
 				}

--- a/nanomq/sub_handler.c
+++ b/nanomq/sub_handler.c
@@ -620,12 +620,10 @@ cache_session(char * clientid, conn_param * cparam, uint32_t pid, void *db)
 	add_session(key_clientid, cs);
 
 	// deep copy connection parameter
-	conn_param *new_cp = NULL;
-	new_conn_param(&new_cp);
-	init_conn_param(new_cp);
-	deep_copy_conn_param(new_cp, cparam);
+	// TODO Do we needs using cparam? in clean session on MQTTV5
+	conn_param_clone(cparam); // Make it not be freed when recv Disconnect EV
 
-	cs->cparam = new_cp;
+	cs->cparam = cparam;
 
 	// step 1 move nano_qos_db to cs struct
 	cs->msg_map = nano_qos_db;
@@ -697,8 +695,8 @@ restore_session(char * clientid, conn_param * cparam, uint32_t pid, void * db)
 	ctx            = cs->cltx;
 
 	// step 0 restore conn param
-	deep_copy_conn_param(cparam, old_cparam);
-	destroy_conn_param(old_cparam);
+//	deep_copy_conn_param(cparam, old_cparam);
+	conn_param_free(old_cparam);
 
 	// step 1 restore cli_ctx and cached_topic_queue
 	if (ctx != NULL) {


### PR DESCRIPTION
1. Reuse disconnect msg when sending will msg.
2. Add refcnt to conn_param structure.
3. Fix the conflict (heap-use-after-free) of conn_param.