### PR TITLE
strcasestr not declare warning fix

### DIFF
--- a/nanolib/file.c
+++ b/nanolib/file.c
@@ -1,3 +1,4 @@
+#include "nanomq.h"
 #include <errno.h>
 #include <fcntl.h>
 #include <stdarg.h>
@@ -10,7 +11,6 @@
 #include <unistd.h>
 
 #include "file.h"
-#include "nanomq.h"
 
 #define NG_MODE (S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)
 


### PR DESCRIPTION
nanomq/nanolib/file.c:302:23: warning: implicit declaration of function ‘strcasestr’; did you mean ‘strcasecmp’?

_GNU_SOURCE is defined in nanomq.h and should be placed before string.h