### PR TITLE
* FIX [conf] only parse conf when requested

### DIFF
--- a/nanomq/apps/broker.c
+++ b/nanomq/apps/broker.c
@@ -643,7 +643,6 @@ broker_start(int argc, char **argv)
 
 	nanomq_conf->parallel = PARALLEL;
 	conf_init(&nanomq_conf);
-	conf_parser(&nanomq_conf, CONF_PATH_NAME);
 
 	for (i = 0; i < argc; i++, temp = 0) {
 		if (!strcmp("-conf", argv[i])) {


### PR DESCRIPTION
When the file defined as `CONF_PATH_NAME` does not exist the broker crashes with:
```
"nanomq.conf ./etc/nanomq.conf" file not found or unreadable
Cannot find the configuration you attemp to set, conf file reading halted, stopped at allow_anonymous
```
This PR fixes this.
Feel free to close this if you have fixed this in some other branch/commit not yet merged.