### PR TITLE
* FIX [pub_handler] Hide the problem of Data race in cparam->ver.

### DIFF
--- a/nanomq/pub_handler.c
+++ b/nanomq/pub_handler.c
@@ -20,7 +20,7 @@
 #include "include/sub_handler.h"
 
 #define ENABLE_RETAIN 1
-#define SUPPORT_MQTT5_0 1
+#define SUPPORT_MQTT5_0 0
 
 static char *bytes_to_str(const unsigned char *src, char *dest, int src_len);
 static void  print_hex(
@@ -309,10 +309,6 @@ encode_pub_message(nng_msg *dest_msg, const nano_work *work,
 	uint32_t buf;
 	properties_type prop_type;
 
-	if (work->cparam) {
-		proto = conn_param_get_protover(work->cparam);
-	}
-
 	debug_msg("start encode message");
 
 	nng_msg_clear(dest_msg);
@@ -364,6 +360,10 @@ encode_pub_message(nng_msg *dest_msg, const nano_work *work,
 		    nng_msg_len(dest_msg));
 
 #if SUPPORT_MQTT5_0
+		if (work->cparam) {
+			proto = conn_param_get_protover(work->cparam);
+		}
+
 		if (PROTOCOL_VERSION_v5 == proto) {
 			// properties
 			// properties length


### PR DESCRIPTION
This **HIDE** the error of data race in the version of cparam.

This data race is caused by free of cparam when publishing.

My solution is to set one more clone and free it when the pub is finished. But it can't be applied easily due to the flexible aio_finish and huge and complex state machine ...