### PR TITLE
No hint fix when log option is OFF and broker exit because web_server address is in use.

### DIFF
--- a/nanomq/web_server.c
+++ b/nanomq/web_server.c
@@ -24,7 +24,7 @@
 
 #define fatal(msg, rv)                                     \
 	{                                                  \
-		debug_msg("%s:%s", msg, nng_strerror(rv)); \
+		printf("%s:%s\n", msg, nng_strerror(rv)); \
 		exit(1);                                   \
 	}
 


### PR DESCRIPTION
fixed #388 