### PR TITLE
fix: nanomq_cli bench sub memory leak

### DIFF
--- a/nanomq_cli/bench.c
+++ b/nanomq_cli/bench.c
@@ -177,6 +177,7 @@ sub_cb(void *arg)
 		}
 		nng_atomic_inc(statistics.recv_cnt);
 		msg         = nng_aio_get_msg(work->aio);
+		nng_msg_free(msg);
 		work->state = RECV;
 		nng_ctx_recv(work->ctx, work->aio);
 		break;


### PR DESCRIPTION
fix https://github.com/nanomq/nanomq/issues/1138