### PR TITLE
docs/en_US/access-control/acl: clarify default action

### DIFF
--- a/docs/en_US/access-control/acl.md
+++ b/docs/en_US/access-control/acl.md
@@ -1,6 +1,7 @@
 # Access Control List
 
 Access Control List (ACL) provides a more fine-grained approach to authorization. It defines rules that are matched from top to bottom. Once a rule is matched, its permission is applied, and the remaining rules are ignored.
+If no rules match, the default permission of `no_match` in [the authentication configuration](introduction.md#authentication-configuration) is applied.
 
 ## Configuration Items
 


### PR DESCRIPTION
Refer to location in manual where the default action (i.e. if no rule matches) is defined. To make it more obvious that the default might not be "deny".

TODOs for me:
[] sign-off commit
[] fix [commit message](https://github.com/nanomq/nanomq/blob/de0ca2bac18a51d3e5efbc6e667018fd313e2e0c/CONTRIBUTING.md#commit-message-guidelines)