### PR TITLE
Fix default max_packet_size

### DIFF
--- a/etc/nanomq.conf
+++ b/etc/nanomq.conf
@@ -6,7 +6,7 @@
 
 mqtt {
     property_size = 32
-    max_packet_size = 260MB
+    max_packet_size = 256MB
     max_mqueue_len = 2048
     retry_interval = 10s
     keepalive_multiplier = 1.25


### PR DESCRIPTION
[The maximum packet size that MQTT protocol spec allows is 256 MB.](https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718023) The current default value does not make sense, and breaks compatibility with various MQTT client libraries, such as Eclipse Paho.