### PR TITLE
Increase cmake_minimum_required to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # found online at https://opensource.org/licenses/MIT.
 # not finished yet #
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 2.8.12...3.10)
 SET(CMAKE_C_STANDARD 99)
 
 project(nanomq-nng)

--- a/nanomq/CMakeLists.txt
+++ b/nanomq/CMakeLists.txt
@@ -4,7 +4,7 @@
 # (LICENSE.txt).  A copy of the license may also be found online at
 # https://opensource.org/licenses/MIT.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.12...3.10)
 
 project(nanomq)
 SET(CMAKE_C_STANDARD 99)

--- a/nanomq_cli/CMakeLists.txt
+++ b/nanomq_cli/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.3...3.10)
 project(nanomq_cli)
 
 


### PR DESCRIPTION
CMake v4.0 released recently, and deprecated support to `cmake < 3.5`
If anyone with `cmake >= 4.0` tries to compile this repo, they'll get 
```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
Compatibility with CMake < 3.5 has been removed from CMake.
```

To fix this, just need to increase the `cmake_minimum_required`
This is an issue we're currently facing in https://github.com/NixOS/nixpkgs
ref: https://github.com/NixOS/nixpkgs/pull/454642