### PR TITLE
chore: enable dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,67 @@
+version: 2
+updates:
+#  - package-ecosystem: cargo
+#    directories:
+#      - nng/extern/msquic
+#      - nng/extern/msquic/submodules/openssl*/pyca-cryptography/src/rust
+#    schedule:
+#      interval: weekly
+#  - package-ecosystem: devcontainers
+#    directories:
+#      - nng/extern/msquic/.devcontainer
+#      - nng/extern/msquic/.devcontainer/developer
+#    schedule:
+#      interval: weekly
+  - package-ecosystem: docker
+    directories:
+      - deploy/docker
+#      - nng/extern/msquic/.devcontainer/developer
+#      - nng/extern/msquic/.docker/ubuntu-20.04
+#      - nng/extern/msquic/.docker/ubuntu-22.04
+#      - nng/extern/msquic/.docker/windows
+#      - nng/extern/msquic/scripts
+    schedule:
+      interval: weekly
+#  - package-ecosystem: dotnet-sdk
+#    directory: nng/extern/msquic/submodules/clog
+#    schedule:
+#      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    allow:
+      - dependency-name: "github/codeql-action"
+        versions: [ ">=4.0.0" ] # stay on "v4" tag (and "v5" in the future)
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: gomod
+    directory: nng/etc/pubrefman
+    schedule:
+      interval: weekly
+#  - package-ecosystem: nuget
+#    directories:
+#      - nng/extern/msquic/scripts/generatevpackpat
+#      - nng/extern/msquic/src/bin/winkernel
+#      - nng/extern/msquic/src/cs/lib
+#      - nng/extern/msquic/src/cs/tool
+#      - nng/extern/msquic/src/plugins/trace/dll
+#      - nng/extern/msquic/src/plugins/trace/exe
+#      - nng/extern/msquic/submodules/clog/src/clog
+#      - nng/extern/msquic/submodules/clog/src/clog2text/clog2text_lttng
+#      - nng/extern/msquic/submodules/clog/src/clog2text/clog2text_windows
+#      - nng/extern/msquic/submodules/clog/src/clogutils
+#      - nng/extern/msquic/submodules/clog/src/converters/syslog2clog
+#      - nng/extern/msquic/submodules/clog/src/decoderTest
+#      - nng/extern/msquic/submodules/xdp-for-windows/src/xdp
+#      - nng/extern/msquic/submodules/xdp-for-windows/src/xdpetwplugin
+#      - nng/extern/msquic/submodules/xdp-for-windows/src/xdpinstaller
+#    schedule:
+#      interval: weekly
+#  - package-ecosystem: pip
+#    directories:
+#      - nng/extern/msquic/submodules/openssl*/**
+#    schedule:
+#      interval: weekly

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -114,7 +114,7 @@ jobs:
         rm -rf ./build
         cd ../
         
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       with:
         fetch-depth: 0
     - run: git submodule update --init --recursive
@@ -198,11 +198,11 @@ jobs:
         sudo mv _packages/nanomq-${pkgversion}-1.${{ steps.prepare.outputs.arch }}.rpm _packages/${{ steps.prepare.outputs.pkg_name }}
         cd _packages; echo $(sha256sum ${{ steps.prepare.outputs.pkg_name }} | awk '{print $1}') > ${{ steps.prepare.outputs.pkg_name }}.sha256
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
       with:
         name: ${{ steps.prepare.outputs.pkg_name }} 
         path: "build/_packages/*"
-    - uses: Rory-Z/upload-release-asset@v1
+    - uses: Rory-Z/upload-release-asset@5f36ae0c882e60ff721ac376ea0f234f89e3c78e # v1
       if: github.event_name == 'release'
       with:
         owner: ${{ github.repository_owner }}
@@ -247,8 +247,8 @@ jobs:
         - "-full"
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/download-artifact@v4
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+    - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
     - run: git submodule update --init --recursive
     - run: docker build -t emqx/nanomq:$(git describe --tags --always)${{ matrix.suffix }} -f deploy/docker/Dockerfile${{ matrix.suffix }} .
     - run: docker run -d -e DEBUG=1 --name nanomq $(docker images emqx/nanomq -q | head -1) --log_level debug
@@ -265,9 +265,9 @@ jobs:
       run: docker inspect nanomq
     - if: failure()
       run: docker logs nanomq
-    - uses: docker/setup-qemu-action@v2
-    - uses: docker/setup-buildx-action@v2
-    - uses: docker/metadata-action@v4
+    - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+    - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+    - uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
       id: meta
       with:
         images: emqx/nanomq
@@ -280,12 +280,12 @@ jobs:
           type=ref,event=tag
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
-    - uses: docker/login-action@v2
+    - uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
       if: github.event_name == 'release'
       with:
         username: ${{ secrets.DOCKER_HUB_USER }}
         password: ${{ secrets.DOCKER_HUB_TOKEN }}
-    - uses: docker/build-push-action@v3
+    - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       if: github.event_name == 'release'
       with:
         platforms: linux/amd64,linux/arm64,linux/arm/v7
@@ -298,7 +298,7 @@ jobs:
   build_archive:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
       - run: git submodule update --init --recursive
@@ -308,7 +308,7 @@ jobs:
           git ls-files --recurse-submodules | tar caf source-with-submodules.tar.gz -T-
 
       - name: Upload release asset
-        uses: Rory-Z/upload-release-asset@v1
+        uses: Rory-Z/upload-release-asset@5f36ae0c882e60ff721ac376ea0f234f89e3c78e # v1
         if: github.event_name == 'release'
         with:
           owner: ${{ github.repository_owner }}

--- a/.github/workflows/check_markdown.yaml
+++ b/.github/workflows/check_markdown.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out code
-      uses: actions/checkout@main
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
     - name: install markdownlint
       run: sudo npm install -g markdownlint-cli
 
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: check out code
-      uses: actions/checkout@main
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
     - name: check directory config
       run: python3 .github/scripts/directory_check.py directory.json $(pwd)/docs

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,12 +39,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       with:
         submodules: 'true'
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@7434149006143a4d75b82a2f411ef15b03ccc2d7 # v4.31.4
       with:
         languages: ${{ matrix.language }}
         queries: +security-and-quality
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@7434149006143a4d75b82a2f411ef15b03ccc2d7 # v4.31.4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -70,4 +70,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@7434149006143a4d75b82a2f411ef15b03ccc2d7 # v4.31.4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: [ ubuntu-22.04 ]
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v3
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       with:
         submodules: recursive
 
@@ -37,7 +37,7 @@ jobs:
       run: cd build && ctest --output-on-failure
 
     - name: Upload report
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         yml: ./.codecov.yml

--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -17,13 +17,13 @@ jobs:
     if: github.repository_owner == 'nanomq'
     steps:
     - name: clone docs
-      uses: actions/checkout@main
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       with:
         fetch-depth: 0
         path: docs-files
 
     - name: clone frontend
-      uses: actions/checkout@main
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       with:
         repository: 'emqx/emqx-io-docs-frontend'
         ref: next
@@ -31,17 +31,17 @@ jobs:
         path: frontend
 
     - name: use python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
         python-version: 3.8
   
     - name: use node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
       with:
         node-version-file: 'frontend/.nvmrc'
   
     - name: use pnpm
-      uses: pnpm/action-setup@v2
+      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       with:
         version: 8
 

--- a/.github/workflows/function_test.yml
+++ b/.github/workflows/function_test.yml
@@ -19,7 +19,7 @@ jobs:
         pip install Jinja2
         pip install paho-mqtt
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
     - run: git submodule update --init --recursive
     - name: build
       run: |

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
         # Fetch submodules at the commit recorded in the superproject (reproducible)
         submodules: recursive
@@ -61,7 +61,7 @@ jobs:
       #   run: cmake --build ${{ env.build }}
 
       - name: Initialize MSVC Code Analysis
-        uses: microsoft/msvc-code-analysis-action@04825f6d9e00f87422d6bf04e1a38b1f3ed60d99
+        uses: microsoft/msvc-code-analysis-action@24c285ab36952c9e9182f4b78dfafbac38a7e5ee # v0.1.1
         # Provide a unique ID to access the sarif output path
         id: run-analysis
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,7 @@ jobs:
   build_windows_packages:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - run: git submodule update --init --recursive
 
       - name: Configure
@@ -26,7 +26,7 @@ jobs:
           Compress-Archive -Path install/* -DestinationPath $pkg_debug_name
           mv $pkg_debug_name ./install/
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: nanomq-debug-windows-x86_64.zip
           path: "install/*.zip"
@@ -39,13 +39,13 @@ jobs:
           Compress-Archive -Path install/* -DestinationPath $pkg_name
           mv $pkg_name ./install/ 
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         if: github.event_name == 'release'
         with:
           name: nanomq-${{ github.event.release.tag_name }}-windows-x86_64.zip
           path: "install/*.zip"
 
-      - uses: svenstaro/upload-release-action@v2
+      - uses: svenstaro/upload-release-action@6b7fa9f267e90b50a19fef07b3596790bb941741 # 2.11.3
         if: github.event_name == 'release'
         with:
           repo_token: ${{ github.token }}


### PR DESCRIPTION
### Chores
- Let Dependabot update docker, github-actions, gitsubmodule and gomod