### PR TITLE
chore: Add Windows ARM64 builds and improve Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,11 @@ updates:
 #      - nng/extern/msquic/scripts
     schedule:
       interval: weekly
-#  - package-ecosystem: dotnet-sdk
+    cooldown: # applies only to version-updates (not security-updates)
+      default-days: 7
+      semver-minor: 14 # wait 14 days before applying minor updates
+      semver-major: 28
+  #  - package-ecosystem: dotnet-sdk
 #    directory: nng/extern/msquic/submodules/clog
 #    schedule:
 #      interval: weekly
@@ -30,17 +34,20 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    allow:
-      - dependency-name: "*"
-      - dependency-type: "all"
+    cooldown:
+      default-days: 7
+      semver-minor-days: 14
+      semver-major-days: 28
   - package-ecosystem: gitsubmodule
     directory: /
     schedule:
       interval: weekly
-  - package-ecosystem: gomod
-    directory: nng/etc/pubrefman
-    schedule:
-      interval: weekly
+    cooldown:
+      default-days: 7
+#  - package-ecosystem: gomod
+#    directory: nng/etc/pubrefman
+#    schedule:
+#      interval: weekly
 #  - package-ecosystem: nuget
 #    directories:
 #      - nng/extern/msquic/scripts/generatevpackpat

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -13,7 +13,8 @@ on:
 
 jobs:
   build_packages:
-    runs-on: ubuntu-22.04
+    if: github.repository == 'nanomq/nanomq' # Only run in upstream repo, not in forks
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
@@ -67,7 +68,7 @@ jobs:
     - name: install mbed-tls
       run: |
         set -eu
-        git clone https://github.com/Mbed-TLS/mbedtls.git && cd mbedtls &&  git checkout tags/v3.3.0
+        git clone --depth 1 --branch v3.5.2 https://github.com/Mbed-TLS/mbedtls.git && cd mbedtls
         mkdir build && cd build
         cmake -DCMAKE_C_COMPILER=${{ matrix.arch[1] }} -DCMAKE_CXX_COMPILER=${{ matrix.arch[2] }} -DENABLE_TESTING=OFF ..
         cmake --build .
@@ -79,8 +80,7 @@ jobs:
       if: matrix.arch[0] != 'riscv64' &&  matrix.arch[0] != 'x86_64'  &&  matrix.arch[0] != 'amd64'
       run: |
         set -eu
-        wget https://sourceforge.net/projects/libuuid/files/libuuid-1.0.3.tar.gz/download -O libuuid-1.0.3.tar.gz 
-        tar zxf libuuid-1.0.3.tar.gz 
+        wget -O- https://sourceforge.net/projects/libuuid/files/libuuid-1.0.3.tar.gz/download | tar xzf -
         cd  libuuid-1.0.3 
         mkdir build 
         cd build  
@@ -92,9 +92,8 @@ jobs:
     - name: install zeromq
       if: matrix.arch[0] != 'riscv64'
       run: |
-        wget https://github.com/zeromq/libzmq/releases/download/v4.3.4/zeromq-4.3.4.tar.gz 
-        tar zxf zeromq-4.3.4.tar.gz 
-        cd zeromq-4.3.4 
+        wget -O- https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz | tar xzf -
+        cd zeromq-4.3.5
         mkdir build 
         cd build 
         cmake -DBUILD_SHARED=OFF      \
@@ -113,11 +112,16 @@ jobs:
         cd ../
         rm -rf ./build
         cd ../
-        
+
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      with:
-        fetch-depth: 0
-    - run: git submodule update --init --recursive
+    - run: git submodule update --init --recursive --depth 1
+
+    - name: Get latest tag
+      id: latest
+      run: |
+        LATEST_TAG="$(curl -s "https://api.github.com/repos/nanomq/nanomq/tags?per_page=1" | jq -r '.[0].name')"
+        echo "LATEST_TAG: $LATEST_TAG"
+        echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
 
     - name: prepare
       id: prepare
@@ -127,7 +131,7 @@ jobs:
           arch="x86_64"
         fi
 
-        pkg_name="nanomq-$(git describe --abbrev=0 --tags)-linux-${arch}${{ matrix.build_type }}.${{ matrix.package_type }}"
+        pkg_name="nanomq-${{ steps.latest.outputs.tag }}-linux-${arch}${{ matrix.build_type }}.${{ matrix.package_type }}"
 
         make_flags="-DCMAKE_C_COMPILER=${{ matrix.arch[1] }} -DCMAKE_CXX_COMPILER=${{ matrix.arch[2] }} -DNNG_ENABLE_TLS=ON"
 
@@ -181,8 +185,8 @@ jobs:
         set -eu
         cd build
         mkdir -p _packages
-        sudo checkinstall --backup=no --install=no --type=debian --arch=${{ steps.prepare.outputs.arch }} --pkgname=nanomq --pkgversion=$(git describe --abbrev=0 --tags) --pkggroup=EMQX --maintainer=EMQX --provides=EMQX --pakdir _packages --recommends=1 --suggests=1 -y
-        sudo mv _packages/nanomq_$(git describe --abbrev=0 --tags)_${{ steps.prepare.outputs.arch }}.deb _packages/${{ steps.prepare.outputs.pkg_name }}
+        sudo checkinstall --backup=no --install=no --type=debian --arch=${{ steps.prepare.outputs.arch }} --pkgname=nanomq --pkgversion=${{ steps.latest.outputs.tag }} --pkggroup=EMQX --maintainer=EMQX --provides=EMQX --pakdir _packages --recommends=1 --suggests=1 -y
+        sudo mv _packages/nanomq_${{ steps.latest.outputs.tag }}_${{ steps.prepare.outputs.arch }}.deb _packages/${{ steps.prepare.outputs.pkg_name }}
         cd _packages; echo $(sha256sum ${{ steps.prepare.outputs.pkg_name }} | awk '{print $1}') > ${{ steps.prepare.outputs.pkg_name }}.sha256
     - name: build rpm
       if: matrix.package_type == 'rpm'
@@ -193,14 +197,14 @@ jobs:
         sudo mkdir -p /root/rpmbuild/SOURCES
         sudo mkdir -p /root/rpmbuild/BUILD
         sudo mkdir -p /root/rpmbuild/BUILDROOT
-        pkgversion="$(git describe --abbrev=0 --tags | tr '-' '_')"
+        pkgversion="$(echo ${{ steps.latest.outputs.tag }} | tr '-' '_')"
         sudo checkinstall --backup=no --install=no --type=rpm --arch=${{ steps.prepare.outputs.arch }} --pkgname=nanomq --pkgversion=${pkgversion} --pkggroup=EMQX --maintainer=EMQX --provides=EMQX --pakdir _packages --recommends=1 --suggests=1 -y
         sudo mv _packages/nanomq-${pkgversion}-1.${{ steps.prepare.outputs.arch }}.rpm _packages/${{ steps.prepare.outputs.pkg_name }}
         cd _packages; echo $(sha256sum ${{ steps.prepare.outputs.pkg_name }} | awk '{print $1}') > ${{ steps.prepare.outputs.pkg_name }}.sha256
 
     - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
-        name: ${{ steps.prepare.outputs.pkg_name }} 
+        name: ${{ steps.prepare.outputs.pkg_name }}
         path: "build/_packages/*"
     - uses: Rory-Z/upload-release-asset@5f36ae0c882e60ff721ac376ea0f234f89e3c78e # v1
       if: github.event_name == 'release'
@@ -216,10 +220,11 @@ jobs:
         aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws configure set default.region us-west-2
-        aws s3 cp --recursive build/_packages s3://packages.emqx/nanomq/$(git describe --abbrev=0 --tags)
+        aws s3 cp --recursive build/_packages s3://packages.emqx/nanomq/${{ steps.latest.outputs.tag }}
 
   build_docker_prepare:
-    runs-on: ubuntu-22.04
+    if: github.repository == 'nanomq/nanomq' # Only run in upstream repo, not in forks
+    runs-on: ubuntu-24.04
     outputs:
       host: ${{ steps.host.outputs.host }}
     steps:
@@ -249,7 +254,7 @@ jobs:
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-    - run: git submodule update --init --recursive
+    - run: git submodule update --init --recursive --depth 1
     - run: docker build -t emqx/nanomq:$(git describe --tags --always)${{ matrix.suffix }} -f deploy/docker/Dockerfile${{ matrix.suffix }} .
     - run: docker run -d -e DEBUG=1 --name nanomq $(docker images emqx/nanomq -q | head -1) --log_level debug
     - name: test docker
@@ -296,7 +301,8 @@ jobs:
         context: .
 
   build_archive:
-    runs-on: ubuntu-22.04
+    if: github.repository == 'nanomq/nanomq' # Only run in upstream repo, not in forks
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -320,7 +326,7 @@ jobs:
 
   publish_packages:
     needs: [build_packages, build_docker]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event_name == 'release'
 
     steps:

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -266,7 +266,7 @@ jobs:
     - if: failure()
       run: docker logs nanomq
     - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-    - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+    - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
     - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
       id: meta
       with:

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -119,7 +119,11 @@ jobs:
     - name: Get latest tag
       id: latest
       run: |
-        LATEST_TAG="$(curl -s "https://api.github.com/repos/nanomq/nanomq/tags?per_page=1" | jq -r '.[0].name')"
+        if [ "${{ github.event_name }}" == "release" ]; then
+          LATEST_TAG="${{ github.ref_name }}"
+        else
+          LATEST_TAG="$(curl -s "https://api.github.com/repos/nanomq/nanomq/tags?per_page=1" | jq -r '.[0].name')"
+        fi
         echo "LATEST_TAG: $LATEST_TAG"
         echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
         submodules: 'true'
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@f67ec12472e1b361f5e1e2085f5e6f85a57e3cd6 # v4.31.4
+      uses: github/codeql-action/init@v4.31.11
       with:
         languages: ${{ matrix.language }}
         queries: +security-and-quality
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@f67ec12472e1b361f5e1e2085f5e6f85a57e3cd6 # v4.31.4
+      uses: github/codeql-action/autobuild@v4.31.11
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -70,4 +70,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@f67ec12472e1b361f5e1e2085f5e6f85a57e3cd6 # v4.31.4
+      uses: github/codeql-action/analyze@v4.31.11

--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -1,6 +1,6 @@
 name: Deploy Docs
 
-concurrency: 
+concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
@@ -19,27 +19,28 @@ jobs:
     - name: clone docs
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         path: docs-files
 
     - name: clone frontend
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
+        fetch-depth: 1
         repository: 'emqx/emqx-io-docs-frontend'
         ref: next
         token: ${{ secrets.CI_GIT_TOKEN }}
         path: frontend
 
     - name: use python
-      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
-        python-version: 3.8
-  
+        python-version: '3.10'
+
     - name: use node.js
       uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       with:
         node-version-file: 'frontend/.nvmrc'
-  
+
     - name: use pnpm
       uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       with:

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -49,7 +49,6 @@ jobs:
           # checkout a branch if desired, e.g. main
           # git checkout main || true
           # git pull origin main || true
-          popd
         shell: pwsh
 
       - name: Configure CMake for Code Analysis
@@ -68,7 +67,7 @@ jobs:
 
       - name: Install
         run: cmake --install build --config Release
-  
+
       # Upload SARIF file to GitHub Code Scanning Alerts
       # - name: Upload SARIF to GitHub
         # uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,8 +26,13 @@ jobs:
           submodules: false # Disable auto-submodule handling to allow shallow fetching
 
       - name: Initialize submodules (shallow)
+        run: git submodule update --init --recursive --depth 1
+
+      - name: Upgrade outdated cmake requirements < 3.5
         run: |
-          git submodule update --init --recursive --depth 1
+          bash -c "
+            find . -name 'CMakeLists.txt' -exec sed -i.bak -E '/cmake_minimum_required(/s/VERSION \([0-2]\.[0-9]*\|3\.[0-4]\))/VERSION 3.5)/' {} +
+          "
 
       - name: Configure
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 1
           submodules: false # Disable auto-submodule handling to allow shallow fetching
 
-      - name: Initialize submodules
+      - name: Initialize submodules (shallow)
         run: |
           git submodule update --init --recursive --depth 1
 
@@ -69,7 +69,7 @@ jobs:
         if: github.event_name == 'release'
         with:
           repo_token: ${{ github.token }}
-          file: install/nanomq*.zip
+          file: install/nanomq-*-${{ matrix.arch }}.zip
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true
@@ -80,7 +80,7 @@ jobs:
           aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws configure set default.region us-west-2
-          aws s3 cp install/ s3://packages.emqx/nanomq/$(git describe --abbrev=0 --tags)/ --recursive --exclude "*" --include "nanomq*.zip"
+          aws s3 cp install/ s3://packages.emqx/nanomq/$(git describe --abbrev=0 --tags)/ --recursive --exclude "*" --include "nanomq-*-${{ matrix.arch }}.zip"
 
       - name: update nanomq.io
         if: github.event_name == 'release'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,12 +44,11 @@ jobs:
         run: |
           $pkg_debug_name = "nanomq-debug-windows-${{ matrix.arch }}.zip"
           Compress-Archive -Path install/* -DestinationPath $pkg_debug_name
-          Move-Item -Path $pkg_debug_name -Destination ./install/
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: nanomq-debug-windows-${{ matrix.arch }}.zip
-          path: "install/*.zip"
+          path: ${{ format('nanomq-debug-windows-{0}.zip', matrix.arch) }}
           retention-days: 7
 
       - name: Package
@@ -82,8 +81,12 @@ jobs:
           aws configure set default.region us-west-2
           aws s3 cp install/ s3://packages.emqx/nanomq/$(git describe --abbrev=0 --tags)/ --recursive --exclude "*" --include "nanomq-*-${{ matrix.arch }}.zip"
 
+  notify-homepage:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    needs: [build_windows_packages] # wait for builds to finish
+    steps:
       - name: update nanomq.io
-        if: github.event_name == 'release'
         run: |
           try {
             $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,9 +38,9 @@ jobs:
         uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
         with:
           path: build
-          key: ${{ runner.os }}-cmake-build-${{ hashFiles('CMakeLists.txt', '**/CMakeLists.txt') }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-cmake-build-${{ hashFiles('CMakeLists.txt', '**/CMakeLists.txt') }}
           restore-keys: |
-            ${{ runner.os }}-cmake-build-
+            ${{ runner.os }}-${{ matrix.arch }}-cmake-build-
 
       - name: Configure
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -79,7 +79,7 @@ jobs:
           aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws configure set default.region us-west-2
-          aws s3 cp install/ s3://packages.emqx/nanomq/$(git describe --abbrev=0 --tags)/ --recursive --exclude "*" --include "nanomq-*-${{ matrix.arch }}.zip"
+          aws s3 cp install/ s3://packages.emqx/nanomq/${{ github.event.release.tag_name }}/ --recursive --exclude "*" --include "nanomq-*-${{ matrix.arch }}.zip"
 
   notify-homepage:
     runs-on: ubuntu-latest
@@ -87,6 +87,7 @@ jobs:
     needs: [build_windows_packages] # wait for builds to finish
     steps:
       - name: update nanomq.io
+        shell: pwsh
         run: |
           try {
             $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Upgrade outdated cmake requirements < 3.5
         run: |
           bash -c "
-            find . -name 'CMakeLists.txt' -exec sed -i.bak -E '/cmake_minimum_required(/s/VERSION \([0-2]\.[0-9]*\|3\.[0-4]\))/VERSION 3.5)/' {} +
+            find . -name 'CMakeLists.txt' -exec sed -i.bak -E '/cmake_minimum_required\(/s/VERSION ([0-2]\.[0-9]+|3\.[0-4])\)/VERSION 3.5)/g' {} +
           "
 
       - name: Configure
@@ -67,7 +67,7 @@ jobs:
         if: github.event_name == 'release'
         with:
           name: nanomq-${{ github.event.release.tag_name }}-windows-${{ matrix.arch }}.zip
-          path: "install/*.zip"
+          path: install/nanomq-${{ github.event.release.tag_name }}-windows-${{ matrix.arch }}.zip
 
       - uses: svenstaro/upload-release-action@6b7fa9f267e90b50a19fef07b3596790bb941741 # 2.11.3
         if: github.event_name == 'release'
@@ -100,7 +100,7 @@ jobs:
             $headers.Add("Content-Type", "application/json")
             $body = "{`"repo`": `"nanomq/nanomq`", `"tag`": `"${{ github.ref_name }}`"}"
             $response = Invoke-WebRequest ${{ secrets.EMQX_IO_RELEASE_API }} -Method 'POST' -Headers $headers -Body $body
-            if ($response.StatusCode -eq 200) {
+            if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
               Write-Host "HTTP status code: $($response.StatusCode)"
               Write-Host "Success"
             } else {

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build_windows_packages:
+    if: github.repository == 'nanomq/nanomq' # Only run in upstream repo, not in forks
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -22,8 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          fetch-depth: 1
-          submodules: false # Disable auto-submodule handling to allow shallow fetching
+          clean: false
 
       - name: Initialize submodules (shallow)
         run: git submodule update --init --recursive --depth 1
@@ -33,6 +33,14 @@ jobs:
           bash -c "
             find . -name 'CMakeLists.txt' -exec sed -i.bak -E '/cmake_minimum_required\(/s/VERSION ([0-2]\.[0-9]+|3\.[0-4])\)/VERSION 3.5)/g' {} +
           "
+
+      - name: Cache CMake build directory
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
+        with:
+          path: build
+          key: ${{ runner.os }}-cmake-build-${{ hashFiles('CMakeLists.txt', '**/CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-cmake-build-
 
       - name: Configure
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,40 +9,60 @@ on:
 
 jobs:
   build_windows_packages:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            arch: x86_64
+          - os: windows-11-arm
+            arch: arm64
+
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - run: git submodule update --init --recursive
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 1
+          submodules: false # Disable auto-submodule handling to allow shallow fetching
+
+      - name: Initialize submodules
+        run: |
+          git submodule update --init --recursive --depth 1
 
       - name: Configure
-        run: cmake -B build -DNNG_ENABLE_SQLITE=ON -DENABLE_RULE_ENGINE=ON -DENABLE_JWT=ON -DBUILD_BENCH=ON
+        run: |
+          $extra_flags = ""
+          if ("${{ matrix.arch }}" -eq "arm64") {
+            $extra_flags = "-A ARM64"
+          }
+          cmake -B build -DNNG_ENABLE_SQLITE=ON -DENABLE_RULE_ENGINE=ON -DENABLE_JWT=ON -DBUILD_BENCH=ON $extra_flags
 
       - name: Build
         run: cmake --build build --config Release --target install
 
       - name: Package-Debug
         run: |
-          $pkg_debug_name="nanomq-debug-windows-x86_64.zip"
+          $pkg_debug_name = "nanomq-debug-windows-${{ matrix.arch }}.zip"
           Compress-Archive -Path install/* -DestinationPath $pkg_debug_name
-          mv $pkg_debug_name ./install/
+          Move-Item -Path $pkg_debug_name -Destination ./install/
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: nanomq-debug-windows-x86_64.zip
+          name: nanomq-debug-windows-${{ matrix.arch }}.zip
           path: "install/*.zip"
           retention-days: 7
 
       - name: Package
         if: github.event_name == 'release'
         run: |
-          $pkg_name="nanomq-${{ github.event.release.tag_name }}-windows-x86_64.zip"
+          $pkg_name="nanomq-${{ github.event.release.tag_name }}-windows-${{ matrix.arch }}.zip"
           Compress-Archive -Path install/* -DestinationPath $pkg_name
-          mv $pkg_name ./install/ 
+          Move-Item -Path $pkg_name -Destination ./install/
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: github.event_name == 'release'
         with:
-          name: nanomq-${{ github.event.release.tag_name }}-windows-x86_64.zip
+          name: nanomq-${{ github.event.release.tag_name }}-windows-${{ matrix.arch }}.zip
           path: "install/*.zip"
 
       - uses: svenstaro/upload-release-action@6b7fa9f267e90b50a19fef07b3596790bb941741 # 2.11.3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "nanonng"]
 	path = nng
 	url = https://github.com/nanomq/NanoNNG.git
+	shallow = true
 [submodule "extern/l8w8jwt"]
 	path = extern/l8w8jwt
 	url = https://github.com/GlitchedPolygons/l8w8jwt.git
+	shallow = true
 [submodule "nanomq_cli/nftp-codec"]
 	path = nanomq_cli/nftp-codec
 	url = https://github.com/nanomq/nftp-codec/
+	shallow = true


### PR DESCRIPTION
### Chores
- Add Windows ARM64 build
- Let Dependabot update `github/codeql-action` again
- Don't let Dependabot update inside git submodules 
- Use Dependabot cooldowns to improve supply chain security
- Improve `deploy_docs` a bit (but it still needs to be upgraded from [legacy](https://github.com/emqx/emqx-docs/blob/release-6.1/deploy_docs_legacy.yaml))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows ARM64 support with per-architecture build artifacts and matrix-driven Windows builds.

* **Chores**
  * Cooldown scheduling added for dependency updates to reduce update churn.
  * Packaging and release now driven by the latest tag for naming and paths.
  * CI/tooling updated and runners modernized; workflows gated to avoid forks running certain jobs.
  * Faster clones via reduced fetch depth and shallow submodules; build tooling and scan action versions updated.
* **Bug Fixes**
  * Improved release notification and upload error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->