### PR TITLE
* FIX [pub_handler] free MQTT v5 properties on decode error paths

### DIFF
--- a/nanomq/pub_handler.c
+++ b/nanomq/pub_handler.c
@@ -1840,6 +1840,10 @@ free_pub_packet(struct pub_packet_struct *pub_packet)
 				pub_packet->payload.len  = 0;
 				log_debug("free payload");
 			}
+		} else if (pub_packet->var_header.pub_arrc.prop_len > 0) {
+			property_free(pub_packet->var_header.pub_arrc.properties);
+			pub_packet->var_header.pub_arrc.prop_len = 0;
+			log_debug("free pub_arrc properties");
 		}
 
 		nng_free(pub_packet, sizeof(struct pub_packet_struct));
@@ -2154,6 +2158,9 @@ decode_pub_message(nano_work *work, uint8_t proto)
 				    // property_get_value(pub_packet->var_header
 				    //                        .publish.properties,
 				    //     SUBSCRIPTION_IDENTIFIER) != NULL
+					property_free(pub_packet->var_header.publish.properties);
+					pub_packet->var_header.publish.properties = NULL;
+					pub_packet->var_header.publish.prop_len   = 0;
 					return PROTOCOL_ERROR;
 				}
 			}
@@ -2162,6 +2169,11 @@ decode_pub_message(nano_work *work, uint8_t proto)
 		if (pos > msg_len) {
 			log_debug("buffer-overflow: pos = %u, msg_len = %lu",
 			    pos, msg_len);
+			if (pub_packet->var_header.publish.properties) {
+				property_free(pub_packet->var_header.publish.properties);
+				pub_packet->var_header.publish.properties = NULL;
+				pub_packet->var_header.publish.prop_len   = 0;
+			}
 			return PROTOCOL_ERROR;
 		}
 
@@ -2201,6 +2213,9 @@ decode_pub_message(nano_work *work, uint8_t proto)
 			if (check_properties(
 			        pub_packet->var_header.pub_arrc.properties, msg) !=
 			    SUCCESS) {
+				property_free(pub_packet->var_header.pub_arrc.properties);
+				pub_packet->var_header.pub_arrc.properties = NULL;
+				pub_packet->var_header.pub_arrc.prop_len   = 0;
 				return PROTOCOL_ERROR;
 			}
 		}

--- a/nanomq/sub_handler.c
+++ b/nanomq/sub_handler.c
@@ -61,6 +61,9 @@ decode_sub_msg(nano_work *work)
 												&sub_pkt->prop_len,
 												true);
 		if (check_properties(sub_pkt->properties, work->msg) != SUCCESS) {
+			property_free(sub_pkt->properties);
+			sub_pkt->properties = NULL;
+			sub_pkt->prop_len   = 0;
 			return PROTOCOL_ERROR;
 		}
 	}
@@ -71,12 +74,22 @@ decode_sub_msg(nano_work *work)
 	payload_ptr = nng_msg_payload_ptr(work->msg);
 	if (payload_ptr == NULL) {
 		log_error("payload_ptr is NULL");
+		if (sub_pkt->properties) {
+			property_free(sub_pkt->properties);
+			sub_pkt->properties = NULL;
+			sub_pkt->prop_len   = 0;
+		}
 		return PROTOCOL_ERROR;
 	}
 
 	tn = nng_zalloc(sizeof(topic_node));
 	if (tn == NULL) {
 		log_error("nng_zalloc");
+		if (sub_pkt->properties) {
+			property_free(sub_pkt->properties);
+			sub_pkt->properties = NULL;
+			sub_pkt->prop_len   = 0;
+		}
 		return NNG_ENOMEM;
 	}
 	sub_pkt->node = tn;

--- a/nanomq/unsub_handler.c
+++ b/nanomq/unsub_handler.c
@@ -49,6 +49,9 @@ decode_unsub_msg(nano_work *work)
 		unsub_pkt->properties =
 		    decode_properties(msg, &vpos, &unsub_pkt->prop_len, false);
 		if (check_properties(unsub_pkt->properties, msg) != SUCCESS) {
+			property_free(unsub_pkt->properties);
+			unsub_pkt->properties = NULL;
+			unsub_pkt->prop_len   = 0;
 			return PROTOCOL_ERROR;
 		}
 	}
@@ -61,6 +64,11 @@ decode_unsub_msg(nano_work *work)
 
 	if ((tn = nng_alloc(sizeof(topic_node))) == NULL) {
 		log_debug("nng_alloc");
+		if (unsub_pkt->properties) {
+			property_free(unsub_pkt->properties);
+			unsub_pkt->properties = NULL;
+			unsub_pkt->prop_len   = 0;
+		}
 		return NNG_ENOMEM;
 	}
 	unsub_pkt->node = tn;
@@ -75,6 +83,11 @@ decode_unsub_msg(nano_work *work)
 		} else {
 			tn->reason_code = UNSPECIFIED_ERROR;
 			log_debug("not utf-8 format string.");
+			if (unsub_pkt->properties) {
+				property_free(unsub_pkt->properties);
+				unsub_pkt->properties = NULL;
+				unsub_pkt->prop_len   = 0;
+			}
 			return PROTOCOL_ERROR;
 		}
 
@@ -83,6 +96,11 @@ decode_unsub_msg(nano_work *work)
 		if (bpos < remaining_len - vpos) {
 			if ((tn = nng_alloc(sizeof(topic_node))) == NULL) {
 				log_debug("nng_alloc");
+				if (unsub_pkt->properties) {
+					property_free(unsub_pkt->properties);
+					unsub_pkt->properties = NULL;
+					unsub_pkt->prop_len   = 0;
+				}
 				return NNG_ENOMEM;
 			}
 			tn->next  = NULL;


### PR DESCRIPTION
## Problem

MQTT v5 messages carry optional "properties" (key-value metadata). When NanoMQ decodes an incoming packet, it allocates memory for those properties via `decode_properties()`. If the properties then fail a validation check (`check_properties()`), or if a subsequent bounds check fires, the code returns `PROTOCOL_ERROR` — but **forgets to free the allocated memory**.

Additionally, `free_pub_packet()` only cleaned up properties for `PUBLISH` packets, silently leaking the property list for `PUBACK/PUBREC/PUBREL/PUBCOMP` packets on every successful decode.

Any client repeatedly sending malformed MQTT v5 packets could gradually exhaust broker memory.

## How It Was Found

Running the `pub_decode_fuzzer` (libFuzzer + AddressSanitizer/LeakSanitizer) against the PUBLISH decoder. The fuzzer generated a malformed MQTT v5 packet that triggered the missing cleanup:

```
==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 64 byte(s) in 1 object(s) allocated from:
    #0 calloc
    #1 nni_zalloc
    #2 property_alloc  mqtt_codec.c:3534
    #3 decode_buf_properties  mqtt_codec.c:4051
    #4 decode_properties  mqtt_codec.c:4084
    #5 decode_pub_message  pub_handler.c:2198
    #6 LLVMFuzzerTestOneInput  pub_decode_fuzzer.c:67

Indirect leak of 128 byte(s) in 2 object(s) allocated from:
    #2 property_alloc  mqtt_codec.c:3534
    #3 property_parse  mqtt_codec.c:3691
    #4 decode_buf_properties  mqtt_codec.c:4063
    ...

SUMMARY: AddressSanitizer: 192 byte(s) leaked in 3 allocation(s).
```

Reproducer saved by fuzzer: `leak-07798e4e924572319f92d2b6f87142bb56cfd227`

## Fix

Added `property_free()` + null the pointer at every `return PROTOCOL_ERROR` that follows a `decode_properties()` call, and added cleanup for `pub_arrc.properties` in `free_pub_packet()`:

| File | Location |
|------|----------|
| `nanomq/pub_handler.c` | PUBLISH `check_properties()` failure |
| `nanomq/pub_handler.c` | PUBLISH buffer-overflow check after property decode |
| `nanomq/pub_handler.c` | PUBACK/PUBREC/PUBREL/PUBCOMP `check_properties()` failure |
| `nanomq/pub_handler.c` | `free_pub_packet()` — add cleanup for `pub_arrc.properties` |
| `nanomq/sub_handler.c` | SUBSCRIBE `check_properties()` failure |
| `nanomq/unsub_handler.c` | UNSUBSCRIBE `check_properties()` failure |

## Verification

- Replayed the fuzzer reproducer after the fix — **clean exit, no LeakSanitizer output**
- Ran fuzzer for 2 minutes (3.5 million executions) — **no crashes or leaks found**
- Full build passes
- 88% of `ctest` suite passes; remaining 16 failures are pre-existing TLS/network tests unrelated to this change

Signed-off-by: Saber Garibi <saberrg@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory cleanup for MQTT v5 message handling to ensure decoded properties are freed and cleared on validation errors and buffer-overflow conditions.
  * Strengthened error handling across publish, subscribe, and unsubscribe decoding paths to prevent resource leaks on early exits and allocation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->