### PR TITLE
Fix webhook memory leaks 

### DIFF
--- a/nanomq/webhook_inproc.c
+++ b/nanomq/webhook_inproc.c
@@ -109,6 +109,7 @@ http_aio_cb(void *arg)
 	nng_lmq          *lmq  = work->lmq;
 	nng_msg          *msg  = NULL;
 	nng_aio          *aio  = work->http_aio;
+	nng_http_res     *res  = NULL;
 	int               rv;
 	uint8_t type;
 
@@ -121,12 +122,12 @@ http_aio_cb(void *arg)
 			nng_aio_set_msg(work->http_aio, NULL);
 			nng_msg_free(msg);
 		}
-        // FIX: Extract and free the pending HTTP response to prevent memory leaks on error
-        nng_http_res *res = nng_aio_get_output(work->http_aio, 1);
-        if (res) {
-            nng_http_res_free(res);
-            nng_aio_set_output(work->http_aio, 1, NULL);
-       }
+		// Always free pending HTTP response object on aio errors.
+		res = nng_aio_get_output(work->http_aio, 1);
+		if (res != NULL) {
+			nng_http_res_free(res);
+			nng_aio_set_output(work->http_aio, 1, NULL);
+		}
 		if (work->conn) {
 			nng_http_conn_close(work->conn);
 			work->conn = NULL;
@@ -148,14 +149,67 @@ http_aio_cb(void *arg)
 	if (msg != NULL) {
 		type = nng_msg_cmd_type(msg);
 		
-		if (type != CMD_HTTPREQ && type != CMD_HTTPRES) {
+		if (type == CMD_HTTPREQ) {
+			// Request body is sent successfully. For async webhook dispatch,
+			// treat this as completed and skip response parsing.
+			log_trace("HTTP Request sent");
+
+			nng_msg_free(msg);
+			nng_aio_set_msg(work->http_aio, NULL);
+			nng_http_conn_close(work->conn);
+			work->conn = NULL;
+			nng_http_req_free(work->req);
+			work->req = NULL;
+			nng_http_client_free(work->client);
+			work->client = NULL;
+			nng_mtx_unlock(work->mtx);
+			log_trace("HTTP Request succeed");
+			
+		} else if (type == CMD_HTTPRES) {
+			// In fire-and-forget mode we should not parse responses.
+			// Keep this as a defensive cleanup path if response read is reintroduced.
+			log_warn("Unexpected CMD_HTTPRES in fire-and-forget webhook path");
+			res = nng_aio_get_output(aio, 1);
+
+			if (res != NULL) {
+				nng_http_res_free(res);
+				nng_aio_set_output(aio, 1, NULL);
+			}
+
+			nng_msg_free(msg);
+			nng_aio_set_msg(work->http_aio, NULL);
+			nng_http_conn_close(work->conn);
+			work->conn = NULL;
+			nng_http_req_free(work->req);
+			work->req = NULL;
+			nng_http_client_free(work->client);
+			work->client = NULL;
+			nng_mtx_unlock(work->mtx);
+			log_trace("HTTP Request succeed");
+
+		} else {
 			// First callback - connection established
 			log_trace("HTTP Connected, sending request");
-			if ((rv = nng_http_req_alloc(&work->req, work->url)) != 0) {
+			work->conn = nng_aio_get_output(aio, 0);
+			if (work->conn == NULL) {
+				log_error("webhook: get conn from aio output failed");
+				nng_msg_free(msg);
+				nng_http_client_free(work->client);
+				work->client = NULL;
 				nng_mtx_unlock(work->mtx);
 				return;
 			}
-			work->conn = nng_aio_get_output(aio, 0);
+
+			if ((rv = nng_http_req_alloc(&work->req, work->url)) != 0) {
+				log_error("nng_http_req_alloc failed: %s", nng_strerror(rv));
+				nng_msg_free(msg);
+				nng_http_conn_close(work->conn);
+				work->conn = NULL;
+				nng_http_client_free(work->client);
+				work->client = NULL;
+				nng_mtx_unlock(work->mtx);
+				return;
+			}
 
 			for (size_t i = 0; i < conf->header_count; i++) {
 				nng_http_req_add_header(work->req, conf->headers[i]->key,
@@ -171,88 +225,46 @@ http_aio_cb(void *arg)
 			nng_http_conn_write_req(work->conn, work->req, aio);
 			nng_mtx_unlock(work->mtx);
 			return;
-			
-		} else if (type == CMD_HTTPREQ) {
-			// Second callback - request sent, now read response
-			log_trace("HTTP Request sent, reading response");
-			
-			nng_http_res *res;
-			if ((rv = nng_http_res_alloc(&res)) != 0) {
-				log_error("Failed to allocate response: %s", nng_strerror(rv));
-				nng_msg_free(msg);
-				nng_aio_set_msg(work->http_aio, NULL);
-				nng_mtx_unlock(work->mtx);
-				nng_http_conn_close(work->conn);
-				work->conn = NULL;
-				nng_http_req_free(work->req);
-				work->req = NULL;
-				nng_http_client_free(work->client);
-				work->client = NULL;
-				return;
-			}
-			
-			// Mark message to indicate we're reading response
-			nng_msg_set_cmd_type(msg, CMD_HTTPRES);
-			nng_aio_set_msg(aio, msg);
-			nng_aio_set_timeout(aio, conf->cancel_timeout);
-			
-			// Store response object for cleanup later
-			nng_aio_set_output(aio, 1, res);
-			
-			// Read the response
-			nng_http_conn_read_res(work->conn, res, aio);
-			nng_mtx_unlock(work->mtx);
-			return;
-			
-		} else if (type == CMD_HTTPRES) {
-			// Third callback - response received, now cleanup
-			nng_http_res *res = nng_aio_get_output(aio, 1);
-
-			if (res) {
-				int status = nng_http_res_get_status(res);
-				log_trace("HTTP Response received: %d", status);
-				nng_http_res_free(res);
-			}
-			
-			nng_msg_free(msg);
-			nng_aio_set_msg(work->http_aio, NULL);
-			nng_mtx_unlock(work->mtx);
-			nng_http_conn_close(work->conn);
-			work->conn = NULL;
-			nng_http_req_free(work->req);
-			work->req = NULL;
-			nng_http_client_free(work->client);
-			work->client = NULL;
-			log_trace("HTTP Request succeed");
 		}
 	} else {
+		// Guard against response-object leaks when aio succeeds but message is absent.
+		res = nng_aio_get_output(aio, 1);
+		if (res != NULL) {
+			nng_http_res_free(res);
+			nng_aio_set_output(aio, 1, NULL);
+		}
 		log_info("NULL msg from webhook aio !!!!");
 		nng_mtx_unlock(work->mtx);
 	}
 
+	nng_mtx_lock(work->mtx);
 	if (!nng_lmq_empty(lmq)) {
-		// send next webhook http request
-		if ((rv = nng_http_client_alloc(&work->client, work->url)) != 0) {
-			log_error("init failed: %s\n", nng_strerror(rv));
+		// Send next webhook HTTP request.
+		if ((rv = nng_lmq_get(lmq, &msg)) != 0) {
+			log_error("Webhook get msg from lmq failed: %s", nng_strerror(rv));
+			nng_mtx_unlock(work->mtx);
 			return;
 		}
-		nng_mtx_lock(work->mtx);
-		nng_lmq_get(lmq, &msg);
+		if ((rv = nng_http_client_alloc(&work->client, work->url)) != 0) {
+			log_error("init failed: %s\n", nng_strerror(rv));
+			nng_msg_free(msg);
+			nng_mtx_unlock(work->mtx);
+			return;
+		}
 		nng_aio_set_timeout(work->http_aio, conf->cancel_timeout);
 		nng_aio_set_msg(work->http_aio, msg);
-		nng_http_client_connect(work->client, work->http_aio);
 		nng_mtx_unlock(work->mtx);
+		nng_http_client_connect(work->client, work->http_aio);
 	} else {
 		size_t lmq_len = nng_lmq_len(work->lmq);
 		// try to reduce lmq cap
 		if (lmq_len > (NANO_LMQ_INIT_CAP * 2)) {
-			nng_mtx_lock(work->mtx);
 			size_t lmq_cap = nng_lmq_cap(work->lmq);
 			if (lmq_cap > (lmq_len * 2)) {
 				nng_lmq_resize(work->lmq, lmq_cap / 2);
 			}
-			nng_mtx_unlock(work->mtx);
 		}
+		nng_mtx_unlock(work->mtx);
 	}
 }
 


### PR DESCRIPTION
Fix memory leaks by ensuring HTTP response objects are freed on errors;

leaks log:
```bash
=================================================================
==4006015==ERROR: LeakSanitizer: detected memory leaks

Indirect leak of 8424 byte(s) in 81 object(s) allocated from:
    #0 0x7f178bee68a3 in calloc (/lib64/libasan.so.8+0xe68a3) (BuildId: d3cb6206dff19da52969c009f4cd93611901c478)
    #1 0x000000489fd6 in nni_zalloc /home/alvin/Projects/EMQ/nanomq/nng/src/platform/posix/posix_alloc.c:34
    #2 0x0000004c4904 in nni_http_res_alloc /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_msg.c:648
    #3 0x0000004ba28c in nng_http_res_alloc /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_public.c:57
    #4 0x000000439bde in http_aio_cb /home/alvin/Projects/EMQ/nanomq/nanomq/webhook_inproc.c:180
    #5 0x000000484b7c in nni_taskq_thread /home/alvin/Projects/EMQ/nanomq/nng/src/core/taskq.c:47
    #6 0x000000485dad in nni_thr_wrap /home/alvin/Projects/EMQ/nanomq/nng/src/core/thread.c:94
    #7 0x000000490fa5 in nni_plat_thr_main /home/alvin/Projects/EMQ/nanomq/nng/src/platform/posix/posix_thread.c:266
    #8 0x7f178be28ee5 in asan_thread_start(void*) (/lib64/libasan.so.8+0x28ee5) (BuildId: d3cb6206dff19da52969c009f4cd93611901c478)

Indirect leak of 7776 byte(s) in 243 object(s) allocated from:
    #0 0x7f178bee68a3 in calloc (/lib64/libasan.so.8+0xe68a3) (BuildId: d3cb6206dff19da52969c009f4cd93611901c478)
    #1 0x000000489fd6 in nni_zalloc /home/alvin/Projects/EMQ/nanomq/nng/src/platform/posix/posix_alloc.c:34
    #2 0x0000004c2f89 in http_add_header /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_msg.c:237
    #3 0x0000004c3b80 in http_parse_header /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_msg.c:459
    #4 0x0000004c5789 in nni_http_res_parse /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_msg.c:912
    #5 0x0000004bf3e8 in http_rd_buf /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_conn.c:203
    #6 0x0000004bfba0 in http_rd_start /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_conn.c:258
    #7 0x0000004c02a3 in http_rd_cb /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_conn.c:350
    #8 0x000000484b7c in nni_taskq_thread /home/alvin/Projects/EMQ/nanomq/nng/src/core/taskq.c:47
    #9 0x000000485dad in nni_thr_wrap /home/alvin/Projects/EMQ/nanomq/nng/src/core/thread.c:94
    #10 0x000000490fa5 in nni_plat_thr_main /home/alvin/Projects/EMQ/nanomq/nng/src/platform/posix/posix_thread.c:266
    #11 0x7f178be28ee5 in asan_thread_start(void*) (/lib64/libasan.so.8+0x28ee5) (BuildId: d3cb6206dff19da52969c009f4cd93611901c478)

Indirect leak of 6075 byte(s) in 243 object(s) allocated from:
    #0 0x7f178bee6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: d3cb6206dff19da52969c009f4cd93611901c478)
    #1 0x000000489f6c in nni_alloc /home/alvin/Projects/EMQ/nanomq/nng/src/platform/posix/posix_alloc.c:22
    #2 0x0000004843d8 in nni_strdup /home/alvin/Projects/EMQ/nanomq/nng/src/core/strs.c:34
    #3 0x0000004c3008 in http_add_header /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_msg.c:244
    #4 0x0000004c3b80 in http_parse_header /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_msg.c:459
    #5 0x0000004c5789 in nni_http_res_parse /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_msg.c:912
    #6 0x0000004bf3e8 in http_rd_buf /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_conn.c:203
    #7 0x0000004bfba0 in http_rd_start /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_conn.c:258
    #8 0x0000004c02a3 in http_rd_cb /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_conn.c:350
    #9 0x000000484b7c in nni_taskq_thread /home/alvin/Projects/EMQ/nanomq/nng/src/core/taskq.c:47
    #10 0x000000485dad in nni_thr_wrap /home/alvin/Projects/EMQ/nanomq/nng/src/core/thread.c:94
    #11 0x000000490fa5 in nni_plat_thr_main /home/alvin/Projects/EMQ/nanomq/nng/src/platform/posix/posix_thread.c:266
    #12 0x7f178be28ee5 in asan_thread_start(void*) (/lib64/libasan.so.8+0x28ee5) (BuildId: d3cb6206dff19da52969c009f4cd93611901c478)

Indirect leak of 2025 byte(s) in 243 object(s) allocated from:
    #0 0x7f178bee6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: d3cb6206dff19da52969c009f4cd93611901c478)
    #1 0x000000489f6c in nni_alloc /home/alvin/Projects/EMQ/nanomq/nng/src/platform/posix/posix_alloc.c:22
    #2 0x0000004843d8 in nni_strdup /home/alvin/Projects/EMQ/nanomq/nng/src/core/strs.c:34
    #3 0x0000004c2faa in http_add_header /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_msg.c:240
    #4 0x0000004c3b80 in http_parse_header /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_msg.c:459
    #5 0x0000004c5789 in nni_http_res_parse /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_msg.c:912
    #6 0x0000004bf3e8 in http_rd_buf /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_conn.c:203
    #7 0x0000004bfba0 in http_rd_start /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_conn.c:258
    #8 0x0000004c02a3 in http_rd_cb /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_conn.c:350
    #9 0x000000484b7c in nni_taskq_thread /home/alvin/Projects/EMQ/nanomq/nng/src/core/taskq.c:47
    #10 0x000000485dad in nni_thr_wrap /home/alvin/Projects/EMQ/nanomq/nng/src/core/thread.c:94
    #11 0x000000490fa5 in nni_plat_thr_main /home/alvin/Projects/EMQ/nanomq/nng/src/platform/posix/posix_thread.c:266
    #12 0x7f178be28ee5 in asan_thread_start(void*) (/lib64/libasan.so.8+0x28ee5) (BuildId: d3cb6206dff19da52969c009f4cd93611901c478)

Indirect leak of 729 byte(s) in 81 object(s) allocated from:
    #0 0x7f178bee6f2b in malloc (/lib64/libasan.so.8+0xe6f2b) (BuildId: d3cb6206dff19da52969c009f4cd93611901c478)
    #1 0x000000489f6c in nni_alloc /home/alvin/Projects/EMQ/nanomq/nng/src/platform/posix/posix_alloc.c:22
    #2 0x0000004843d8 in nni_strdup /home/alvin/Projects/EMQ/nanomq/nng/src/core/strs.c:34
    #3 0x0000004c2207 in http_set_string /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_msg.c:67
    #4 0x0000004c4ccf in nni_http_res_set_version /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_msg.c:703
    #5 0x0000004c530c in http_res_parse_line /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_msg.c:837
    #6 0x0000004c57a4 in nni_http_res_parse /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_msg.c:914
    #7 0x0000004bf3e8 in http_rd_buf /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_conn.c:203
    #8 0x0000004bfba0 in http_rd_start /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_conn.c:258
    #9 0x0000004c02a3 in http_rd_cb /home/alvin/Projects/EMQ/nanomq/nng/src/supplemental/http/http_conn.c:350
    #10 0x000000484b7c in nni_taskq_thread /home/alvin/Projects/EMQ/nanomq/nng/src/core/taskq.c:47
    #11 0x000000485dad in nni_thr_wrap /home/alvin/Projects/EMQ/nanomq/nng/src/core/thread.c:94
    #12 0x000000490fa5 in nni_plat_thr_main /home/alvin/Projects/EMQ/nanomq/nng/src/platform/posix/posix_thread.c:266
    #13 0x7f178be28ee5 in asan_thread_start(void*) (/lib64/libasan.so.8+0x28ee5) (BuildId: d3cb6206dff19da52969c009f4cd93611901c478)

SUMMARY: AddressSanitizer: 25029 byte(s) leaked in 891 allocation(s).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook dispatch reliability with enhanced resource cleanup and error handling for HTTP requests and responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanomq/nanomq/pull/2306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->