### PR TITLE
Update check_properties() function to use command type instead of nng_msg for validation

### DIFF
--- a/nanomq/pub_handler.c
+++ b/nanomq/pub_handler.c
@@ -2167,7 +2167,7 @@ decode_pub_message(nano_work *work, uint8_t proto)
 			if (pub_packet->var_header.publish.properties) {
 				if (check_properties(
 				        pub_packet->var_header.publish
-				            .properties, msg) != 0) {
+				            .properties, CMD_PUBLISH_V5) != 0) {
 					// check if subid exist in publish msg from client
 				    // property_get_value(pub_packet->var_header
 				    //                        .publish.properties,
@@ -2224,13 +2224,16 @@ decode_pub_message(nano_work *work, uint8_t proto)
 			    decode_properties(msg, &pos,
 			        &pub_packet->var_header.pub_arrc.prop_len,
 			        false);
-			if (check_properties(
-			        pub_packet->var_header.pub_arrc.properties, msg) !=
-			    SUCCESS) {
-				property_free(pub_packet->var_header.pub_arrc.properties);
-				pub_packet->var_header.pub_arrc.properties = NULL;
-				pub_packet->var_header.pub_arrc.prop_len   = 0;
-				return PROTOCOL_ERROR;
+			int rv;
+			if ((rv = check_properties(
+			         pub_packet->var_header.pub_arrc.properties,
+			         nng_msg_get_cmd_type(msg))) != SUCCESS) {
+				property_free(pub_packet->var_header.pub_arrc
+				        .properties);
+				pub_packet->var_header.pub_arrc.properties =
+				    NULL;
+				pub_packet->var_header.pub_arrc.prop_len = 0;
+				return rv;
 			}
 		}
 		break;

--- a/nanomq/sub_handler.c
+++ b/nanomq/sub_handler.c
@@ -69,7 +69,8 @@ decode_sub_msg(nano_work *work)
 												(uint32_t *)&bpos,
 												&sub_pkt->prop_len,
 												true);
-		if (check_properties(sub_pkt->properties, work->msg) != SUCCESS) {
+		if (check_properties(sub_pkt->properties,
+		        nng_msg_get_cmd_type(work->msg)) != SUCCESS) {
 			FREE_SUB_PROPERTIES(sub_pkt);
 			return PROTOCOL_ERROR;
 		}

--- a/nanomq/unsub_handler.c
+++ b/nanomq/unsub_handler.c
@@ -60,7 +60,8 @@ decode_unsub_msg(nano_work *work)
 	if (MQTT_PROTOCOL_VERSION_v5 == proto_ver) {
 		unsub_pkt->properties =
 		    decode_properties(msg, &vpos, &unsub_pkt->prop_len, false);
-		if (check_properties(unsub_pkt->properties, msg) != SUCCESS) {
+		if (check_properties(unsub_pkt->properties,
+		        nng_msg_get_cmd_type(msg)) != SUCCESS) {
 			FREE_UNSUB_PROPERTIES(unsub_pkt);
 			return PROTOCOL_ERROR;
 		}


### PR DESCRIPTION
Fix issue https://github.com/emqx/NanoMQ_mirror/issues/604

Must merge NNG PR first https://github.com/nanomq/NanoNNG/pull/1541

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced MQTT property validation across publish, subscribe, and unsubscribe message handlers to improve error handling and resource cleanup during protocol processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->