### PR TITLE
docs: HTTP acl_req authorizes PUBLISH and SUBSCRIBE

### DIFF
--- a/docs/en_US/access-control/http.md
+++ b/docs/en_US/access-control/http.md
@@ -2,11 +2,11 @@
 
 HTTP Authorization provides yet another method for authorization. NanoMQ sends an HTTP POST request in the format as configured to the target HTTP server to authorize MQTT clients, and relies on the return code of the HTTP POST for the result. It enables extensive authorization with an external HTTP service.
 
-Authorization is checked at two points: `auth_req` (and `super_req`) run on `CONNECT`, and `acl_req` runs on each `PUBLISH` and `SUBSCRIBE`.
+Authorization is checked at two points: `auth_req` runs on `CONNECT`; `super_req` and `acl_req` run on `PUBLISH` and `SUBSCRIBE`.
 
 ::: tip
 
-`acl_req` authorizes `PUBLISH` and `SUBSCRIBE` operations. NanoMQ calls the ACL endpoint per message, sending the requested `topic` (`%t`) and the `access` type (`%A`, where `1` = subscribe and `2` = publish), and enforces the returned decision.
+On each `PUBLISH` and `SUBSCRIBE`, `super_req` (if configured) is checked first — a success marks the client as a superuser and skips the ACL check — otherwise `acl_req` decides. The request carries the requested `topic` (`%t`, comma-separated if a `SUBSCRIBE` contains multiple topic filters) and the `access` type (`%A`, where `1` = subscribe and `2` = publish), and the returned decision is enforced. When `cache_ttl` is set, allowed results are cached and repeated checks skip the HTTP request until the cache expires.
 
 :::
 

--- a/docs/en_US/access-control/http.md
+++ b/docs/en_US/access-control/http.md
@@ -1,10 +1,12 @@
 # HTTP Authorization Configuration
 
-HTTP Authorization provides yet another method for authorization. NanoMQ will send an HTTP POST request in the format as configured to the target HTTP server when receiving `CONNECT` packets from MQTT clients, and relies on the return code of HTTP POST for the client's authorization. It enables extensive authorization with external HTTP service.
+HTTP Authorization provides yet another method for authorization. NanoMQ sends an HTTP POST request in the format as configured to the target HTTP server to authorize MQTT clients, and relies on the return code of the HTTP POST for the result. It enables extensive authorization with an external HTTP service.
+
+Authorization is checked at two points: `auth_req` (and `super_req`) run on `CONNECT`, and `acl_req` runs on each `PUBLISH` and `SUBSCRIBE`.
 
 ::: tip
 
-For now, HTTP Authorization only supports `MQTT CONNECT`, will add support for `PUBLISH` & `SUBSCRIBE` in the future. Please post an issue if you need further support urgently.
+`acl_req` authorizes `PUBLISH` and `SUBSCRIBE` operations. NanoMQ calls the ACL endpoint per message, sending the requested `topic` (`%t`) and the `access` type (`%A`, where `1` = subscribe and `2` = publish), and enforces the returned decision.
 
 :::
 

--- a/docs/zh_CN/access-control/http.md
+++ b/docs/zh_CN/access-control/http.md
@@ -1,10 +1,10 @@
 # HTTP 认证
 
-NanoMQ 同时支持 HTTP 认证。HTTP 认证功能支持用户使用外部 HTTP 服务进行客户端行为的授权。当 NanoMQ 从 MQTT 客户端接收 `CONNECT` 数据包时，NanoMQ 将按照配置为目标 HTTP 服务器的格式发送 HTTP POST 请求，并依靠 HTTP POST 的返回码进行客户端授权决定是否允许其连接。
+NanoMQ 同时支持 HTTP 认证。HTTP 认证功能支持用户使用外部 HTTP 服务进行客户端行为的授权。NanoMQ 将按照配置向目标 HTTP 服务器发送 HTTP POST 请求，并依靠 HTTP POST 的返回码进行授权判定。授权在两个阶段进行：`auth_req`（及 `super_req`）在 `CONNECT` 时调用，`acl_req` 在每次 `PUBLISH` 和 `SUBSCRIBE` 时调用。
 
 ::: tip
 
-目前，HTTP Authorization 仅支持 `MQTT CONNECT`，将来将添加对 `PUBLISH` 和 `SUBSCRIB` 的支持。如果您急需进一步的支持，请在 Github 发布 Feature Request。
+`acl_req` 支持对 `PUBLISH` 和 `SUBSCRIBE` 操作进行授权。NanoMQ 会在每条消息时调用 ACL 端点，发送请求的主题（`%t`）与访问类型（`%A`，其中 `1` 表示订阅，`2` 表示发布），并执行返回的授权决定。`auth_req`/`super_req` 则在 `CONNECT` 时调用。
 
 :::
 

--- a/docs/zh_CN/access-control/http.md
+++ b/docs/zh_CN/access-control/http.md
@@ -1,10 +1,10 @@
 # HTTP 认证
 
-NanoMQ 同时支持 HTTP 认证。HTTP 认证功能支持用户使用外部 HTTP 服务进行客户端行为的授权。NanoMQ 将按照配置向目标 HTTP 服务器发送 HTTP POST 请求，并依靠 HTTP POST 的返回码进行授权判定。授权在两个阶段进行：`auth_req`（及 `super_req`）在 `CONNECT` 时调用，`acl_req` 在每次 `PUBLISH` 和 `SUBSCRIBE` 时调用。
+NanoMQ 同时支持 HTTP 认证。HTTP 认证功能支持用户使用外部 HTTP 服务进行客户端行为的授权。NanoMQ 将按照配置向目标 HTTP 服务器发送 HTTP POST 请求，并依靠 HTTP POST 的返回码进行授权判定。授权在两个阶段进行：`auth_req` 在 `CONNECT` 时调用；`super_req` 和 `acl_req` 在 `PUBLISH` 和 `SUBSCRIBE` 时调用。
 
 ::: tip
 
-`acl_req` 支持对 `PUBLISH` 和 `SUBSCRIBE` 操作进行授权。NanoMQ 会在每条消息时调用 ACL 端点，发送请求的主题（`%t`）与访问类型（`%A`，其中 `1` 表示订阅，`2` 表示发布），并执行返回的授权决定。`auth_req`/`super_req` 则在 `CONNECT` 时调用。
+每次 `PUBLISH` 和 `SUBSCRIBE` 时，若配置了 `super_req` 则先进行检查——通过即视为超级用户并跳过 ACL 检查——否则由 `acl_req` 判定。请求中包含所请求的主题（`%t`，若 `SUBSCRIBE` 包含多个主题过滤器则以逗号分隔）与访问类型（`%A`，其中 `1` 表示订阅，`2` 表示发布），并执行返回的授权决定。当设置了 `cache_ttl` 时，允许的结果会被缓存，重复检查将跳过 HTTP 请求，直到缓存过期。
 
 :::
 


### PR DESCRIPTION
The HTTP authorization docs stated that HTTP Authorization only supports MQTT CONNECT and that PUBLISH/SUBSCRIBE support would come later. acl_req is in fact invoked on each PUBLISH and SUBSCRIBE with the topic (%t) and access type (%A; 1 = subscribe, 2 = publish) and enforces the returned decision. Update the en_US and zh_CN (machine translated) docs to describe the current behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified HTTP authorization behavior across MQTT `CONNECT`, `PUBLISH`, and `SUBSCRIBE`.
  * Documented the two-stage authorization flow and how results are enforced for each relevant message.
  * Updated request placeholders and explained how topic and access type are conveyed.
  * Removed outdated guidance that HTTP authorization applied only to `CONNECT`.
  * Added notes on caching behavior to reduce repeated HTTP authorization checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->