### PR TITLE
Apply ACL-file changes on `nanomq reload` (lock-free, hazard-pointer reclamation)

### DIFF
--- a/nanomq/CMakeLists.txt
+++ b/nanomq/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SOURCES
     conf_api.c
     cmd_proc.c
     acl_handler.c
+    acl_hazard.c
     mqtt_api.c
     nanomq.c
     apps/broker.c

--- a/nanomq/acl_handler.c
+++ b/nanomq/acl_handler.c
@@ -1,5 +1,6 @@
 #ifdef ACL_SUPP
 #include "include/acl_handler.h"
+#include "include/acl_hazard.h"
 #include "nng/protocol/mqtt/mqtt_parser.h"
 #include "nng/supplemental/nanolib/log.h"
 
@@ -113,7 +114,18 @@ auth_acl(conf *config, acl_action_type act_type, conn_param *param,
 {
 	conn_param_clone(param);
 
-	conf_acl *acl = &config->acl;
+	// Acquire the live ACL snapshot under hazard-pointer protection so the
+	// reload writer cannot free the rules we are about to traverse. If the
+	// registry is not ready (pre-startup) or is exhausted, fall back to the
+	// config-embedded ACL: that memory is part of config and is never freed
+	// at runtime, so the fallback is memory-safe (it is empty post-init,
+	// yielding the acl_nomatch policy). Whichever we use, we traverse a single
+	// consistent snapshot.
+	conf_acl *acl        = nmq_acl_hazard_acquire();
+	bool      hp_held    = (acl != NULL);
+	if (!hp_held) {
+		acl = &config->acl;
+	}
 
 	bool match     = false;
 	bool sub_match = true;
@@ -253,6 +265,8 @@ auth_acl(conf *config, acl_action_type act_type, conn_param *param,
 			for (size_t j = 0; j < rule->topic_count && found != true; j++) {
 				rule_topic = replace_topic(rule->topics[j], param);
 				if (rule_topic == NULL) {
+					if (hp_held)
+						nmq_acl_hazard_release();
 					conn_param_free(param);
 					return false;
 				}
@@ -284,6 +298,11 @@ auth_acl(conf *config, acl_action_type act_type, conn_param *param,
 
 		break;
 	}
+
+	// Done traversing the snapshot; release the hazard pointer so the writer
+	// can reclaim this snapshot once it is retired.
+	if (hp_held)
+		nmq_acl_hazard_release();
 
 	conn_param_free(param);
 

--- a/nanomq/acl_handler.c
+++ b/nanomq/acl_handler.c
@@ -115,15 +115,20 @@ auth_acl(conf *config, acl_action_type act_type, conn_param *param,
 	conn_param_clone(param);
 
 	// Acquire the live ACL snapshot under hazard-pointer protection so the
-	// reload writer cannot free the rules we are about to traverse. If the
-	// registry is not ready (pre-startup) or is exhausted, fall back to the
-	// config-embedded ACL: that memory is part of config and is never freed
-	// at runtime, so the fallback is memory-safe (it is empty post-init,
-	// yielding the acl_nomatch policy). Whichever we use, we traverse a single
-	// consistent snapshot.
+	// reload writer cannot free the rules we are about to traverse. On
+	// acquire failure pick a path that is both memory-safe and fail-safe:
+	// before init the rules still live in config->acl, so traversing it
+	// enforces the real boot rules; after init config->acl is empty (the
+	// rules were moved into the snapshot), so evaluating it would silently
+	// fall through to the acl_nomatch policy (allow by default); deny
+	// instead.
 	conf_acl *acl        = nmq_acl_hazard_acquire();
-	bool      hp_held    = (acl != NULL);
-	if (!hp_held) {
+	bool      is_hp_held = (acl != NULL);
+	if (!is_hp_held) {
+		if (nmq_acl_hazard_ready()) {
+			conn_param_free(param);
+			return false;
+		}
 		acl = &config->acl;
 	}
 
@@ -265,7 +270,7 @@ auth_acl(conf *config, acl_action_type act_type, conn_param *param,
 			for (size_t j = 0; j < rule->topic_count && found != true; j++) {
 				rule_topic = replace_topic(rule->topics[j], param);
 				if (rule_topic == NULL) {
-					if (hp_held)
+					if (is_hp_held)
 						nmq_acl_hazard_release();
 					conn_param_free(param);
 					return false;
@@ -301,7 +306,7 @@ auth_acl(conf *config, acl_action_type act_type, conn_param *param,
 
 	// Done traversing the snapshot; release the hazard pointer so the writer
 	// can reclaim this snapshot once it is retired.
-	if (hp_held)
+	if (is_hp_held)
 		nmq_acl_hazard_release();
 
 	conn_param_free(param);

--- a/nanomq/acl_hazard.c
+++ b/nanomq/acl_hazard.c
@@ -1,9 +1,92 @@
 #ifdef ACL_SUPP
 #include "include/acl_hazard.h"
+#include "nng/nng.h"
 #include "nng/supplemental/nanolib/log.h"
 
-#include <pthread.h>
 #include <stdlib.h>
+
+// Atomic + TLS portability shim. nng's public API offers nng_atomic_ptr, but
+// hazard pointers also need an ARRAY of per-thread slots and a thread-local
+// slot index, which have no public nng primitive; so the raw operations are
+// wrapped here once, per compiler. GCC/Clang use __atomic builtins; MSVC uses
+// Interlocked intrinsics (full-barrier, so every SEQ_CST requirement below is
+// met, if over-satisfied) and __declspec(thread).
+#if defined(__GNUC__) || defined(__clang__)
+
+#define ACL_HAZ_TLS __thread
+
+static inline conf_acl *
+haz_ptr_load(conf_acl **p)
+{
+	return __atomic_load_n(p, __ATOMIC_SEQ_CST);
+}
+
+static inline void
+haz_ptr_store(conf_acl **p, conf_acl *v)
+{
+	__atomic_store_n(p, v, __ATOMIC_SEQ_CST);
+}
+
+static inline int
+haz_int_load(int *p)
+{
+	return __atomic_load_n(p, __ATOMIC_SEQ_CST);
+}
+
+static inline void
+haz_int_store(int *p, int v)
+{
+	__atomic_store_n(p, v, __ATOMIC_SEQ_CST);
+}
+
+static inline int
+haz_int_fetch_add(int *p, int v)
+{
+	return __atomic_fetch_add(p, v, __ATOMIC_SEQ_CST);
+}
+
+#elif defined(_MSC_VER)
+
+#include <intrin.h>
+
+#define ACL_HAZ_TLS __declspec(thread)
+
+static __forceinline conf_acl *
+haz_ptr_load(conf_acl **p)
+{
+	// CAS(NULL, NULL) is a full-barrier load: it only writes when *p is
+	// already NULL, and then writes the same NULL back.
+	return (conf_acl *) _InterlockedCompareExchangePointer(
+	    (void *volatile *) p, NULL, NULL);
+}
+
+static __forceinline void
+haz_ptr_store(conf_acl **p, conf_acl *v)
+{
+	(void) _InterlockedExchangePointer((void *volatile *) p, v);
+}
+
+static __forceinline int
+haz_int_load(int *p)
+{
+	return (int) _InterlockedCompareExchange((volatile long *) p, 0, 0);
+}
+
+static __forceinline void
+haz_int_store(int *p, int v)
+{
+	(void) _InterlockedExchange((volatile long *) p, (long) v);
+}
+
+static __forceinline int
+haz_int_fetch_add(int *p, int v)
+{
+	return (int) _InterlockedExchangeAdd((volatile long *) p, (long) v);
+}
+
+#else
+#error "acl_hazard.c needs GCC/Clang __atomic builtins or MSVC intrinsics"
+#endif
 
 // Maximum number of ACL readers that may hold a hazard pointer concurrently.
 // This bounds the number of nng worker / callback threads that can be inside
@@ -13,7 +96,7 @@
 
 // The published pointer to the live, immutable ACL snapshot. Written only by
 // the single reload writer; read by every ACL reader. Accessed exclusively via
-// __atomic builtins so the publication is visible without a lock.
+// the atomic shim above so the publication is visible without a lock.
 static conf_acl *acl_current = NULL;
 
 // Set once nmq_acl_hazard_init has published the first snapshot. Readers that
@@ -27,12 +110,12 @@ static int hazard_ready = 0;
 static conf_acl *hazard_slots[ACL_HAZARD_MAX];
 
 // High-water mark of claimed slots; the writer only needs to scan this many.
-// Monotonically increased via __atomic; never decreased (threads keep their
+// Monotonically increased atomically; never decreased (threads keep their
 // slot for their lifetime).
 static int hazard_high = 0;
 
 // This thread's claimed slot index, or -1 if it has not claimed one yet.
-static __thread int t_hazard_index = -1;
+static ACL_HAZ_TLS int t_hazard_index = -1;
 
 // Retire list of replaced snapshots awaiting reclamation, plus its lock. Both
 // are writer-side only (off the read hot path): the single reload writer pushes
@@ -42,8 +125,8 @@ typedef struct retire_node {
 	struct retire_node *next;
 } retire_node;
 
-static retire_node *   retire_head = NULL;
-static pthread_mutex_t retire_lock = PTHREAD_MUTEX_INITIALIZER;
+static retire_node *retire_head = NULL;
+static nng_mtx *    retire_mtx  = NULL; // allocated by nmq_acl_hazard_init
 
 // hazard_claim_slot lazily assigns this thread a hazard slot the first time it
 // reads the ACL, remembering the index in thread-local storage. Returns the
@@ -54,11 +137,11 @@ hazard_claim_slot(void)
 	if (t_hazard_index >= 0) {
 		return t_hazard_index;
 	}
-	int idx = __atomic_fetch_add(&hazard_high, 1, __ATOMIC_SEQ_CST);
+	int idx = haz_int_fetch_add(&hazard_high, 1);
 	if (idx >= ACL_HAZARD_MAX) {
 		// Undo the over-increment so the high-water mark stays bounded by
 		// ACL_HAZARD_MAX for the writer's scan.
-		__atomic_fetch_sub(&hazard_high, 1, __ATOMIC_SEQ_CST);
+		haz_int_fetch_add(&hazard_high, -1);
 		return -1;
 	}
 	t_hazard_index = idx;
@@ -70,12 +153,12 @@ hazard_claim_slot(void)
 static bool
 hazard_is_protected(conf_acl *p)
 {
-	int high = __atomic_load_n(&hazard_high, __ATOMIC_SEQ_CST);
+	int high = haz_int_load(&hazard_high);
 	if (high > ACL_HAZARD_MAX) {
 		high = ACL_HAZARD_MAX;
 	}
 	for (int i = 0; i < high; i++) {
-		if (__atomic_load_n(&hazard_slots[i], __ATOMIC_SEQ_CST) == p) {
+		if (haz_ptr_load(&hazard_slots[i]) == p) {
 			return true;
 		}
 	}
@@ -98,7 +181,7 @@ acl_retire(conf_acl *old)
 	}
 	node->acl = old;
 
-	pthread_mutex_lock(&retire_lock);
+	nng_mtx_lock(retire_mtx);
 	node->next  = retire_head;
 	retire_head = node;
 
@@ -114,13 +197,19 @@ acl_retire(conf_acl *old)
 			pp = &cur->next;
 		}
 	}
-	pthread_mutex_unlock(&retire_lock);
+	nng_mtx_unlock(retire_mtx);
 }
 
 void
 nmq_acl_hazard_init(conf *config)
 {
-	if (__atomic_load_n(&hazard_ready, __ATOMIC_SEQ_CST)) {
+	if (haz_int_load(&hazard_ready)) {
+		return;
+	}
+
+	if (retire_mtx == NULL && nng_mtx_alloc(&retire_mtx) != 0) {
+		log_error("ACL hazard: retire mutex alloc failed; ACL "
+		          "reload disabled");
 		return;
 	}
 
@@ -141,14 +230,14 @@ nmq_acl_hazard_init(conf *config)
 	config->acl.rule_count = 0;
 	config->acl.rules      = NULL;
 
-	__atomic_store_n(&acl_current, snap, __ATOMIC_SEQ_CST);
-	__atomic_store_n(&hazard_ready, 1, __ATOMIC_SEQ_CST);
+	haz_ptr_store(&acl_current, snap);
+	haz_int_store(&hazard_ready, 1);
 }
 
 conf_acl *
 nmq_acl_hazard_acquire(void)
 {
-	if (!__atomic_load_n(&hazard_ready, __ATOMIC_SEQ_CST)) {
+	if (!haz_int_load(&hazard_ready)) {
 		return NULL;
 	}
 
@@ -167,14 +256,14 @@ nmq_acl_hazard_acquire(void)
 	// reader's publish. If the writer swapped in between, retry.
 	conf_acl *p;
 	do {
-		p = __atomic_load_n(&acl_current, __ATOMIC_SEQ_CST);
-		__atomic_store_n(&hazard_slots[idx], p, __ATOMIC_SEQ_CST);
-	} while (p != __atomic_load_n(&acl_current, __ATOMIC_SEQ_CST));
+		p = haz_ptr_load(&acl_current);
+		haz_ptr_store(&hazard_slots[idx], p);
+	} while (p != haz_ptr_load(&acl_current));
 
 	if (p == NULL) {
 		// Nothing published (should not happen post-init); clear and fall
 		// back so the caller does not dereference NULL.
-		__atomic_store_n(&hazard_slots[idx], NULL, __ATOMIC_SEQ_CST);
+		haz_ptr_store(&hazard_slots[idx], NULL);
 	}
 	return p;
 }
@@ -182,7 +271,7 @@ nmq_acl_hazard_acquire(void)
 bool
 nmq_acl_hazard_ready(void)
 {
-	return __atomic_load_n(&hazard_ready, __ATOMIC_SEQ_CST) != 0;
+	return haz_int_load(&hazard_ready) != 0;
 }
 
 void
@@ -190,7 +279,7 @@ nmq_acl_hazard_release(void)
 {
 	int idx = t_hazard_index;
 	if (idx >= 0) {
-		__atomic_store_n(&hazard_slots[idx], NULL, __ATOMIC_SEQ_CST);
+		haz_ptr_store(&hazard_slots[idx], NULL);
 	}
 }
 
@@ -200,7 +289,7 @@ reload_acl_config(conf *config, conf *new_conf)
 	// If startup init never published a snapshot, readers are on the
 	// config-embedded fallback ACL and would never see this reload; no-op so
 	// the enable gate and the rules readers traverse stay consistent.
-	if (!__atomic_load_n(&hazard_ready, __ATOMIC_SEQ_CST)) {
+	if (!haz_int_load(&hazard_ready)) {
 		log_error("ACL hazard: registry not initialized; skipping ACL "
 		          "reload");
 		return;
@@ -227,8 +316,8 @@ reload_acl_config(conf *config, conf *new_conf)
 	config->acl_deny_action = new_conf->acl_deny_action;
 
 	// Single-writer publish: load-then-store, no CAS required.
-	conf_acl *old = __atomic_load_n(&acl_current, __ATOMIC_SEQ_CST);
-	__atomic_store_n(&acl_current, snap, __ATOMIC_SEQ_CST);
+	conf_acl *old = haz_ptr_load(&acl_current);
+	haz_ptr_store(&acl_current, snap);
 
 	// Update the caller-visible enable gate only after the snapshot is live,
 	// so a reader that passes a newly-enabled gate always finds the new rules.

--- a/nanomq/acl_hazard.c
+++ b/nanomq/acl_hazard.c
@@ -1,0 +1,220 @@
+#ifdef ACL_SUPP
+#include "include/acl_hazard.h"
+#include "nng/supplemental/nanolib/log.h"
+
+#include <pthread.h>
+#include <stdlib.h>
+
+// Maximum number of ACL readers that may hold a hazard pointer concurrently.
+// This bounds the number of nng worker / callback threads that can be inside
+// auth_acl at the same time. It is intentionally generous; if it is ever
+// exhausted the reader falls back to a memory-safe deny (see acquire) and logs.
+#define ACL_HAZARD_MAX 1024
+
+// The published pointer to the live, immutable ACL snapshot. Written only by
+// the single reload writer; read by every ACL reader. Accessed exclusively via
+// __atomic builtins so the publication is visible without a lock.
+static conf_acl *acl_current = NULL;
+
+// Set once nmq_acl_hazard_init has published the first snapshot. Readers that
+// observe this as 0 fall back to the memory-safe config-embedded ACL.
+static int hazard_ready = 0;
+
+// Per-reader hazard slots. A reader publishes the snapshot it is traversing
+// into its own slot; the writer scans all claimed slots before reclaiming a
+// retired snapshot. A reader only ever writes its OWN slot, so reader cores do
+// not share a written cache line (unlike an rwlock reader counter).
+static conf_acl *hazard_slots[ACL_HAZARD_MAX];
+
+// High-water mark of claimed slots; the writer only needs to scan this many.
+// Monotonically increased via __atomic; never decreased (threads keep their
+// slot for their lifetime).
+static int hazard_high = 0;
+
+// This thread's claimed slot index, or -1 if it has not claimed one yet.
+static __thread int t_hazard_index = -1;
+
+// Retire list of replaced snapshots awaiting reclamation, plus its lock. Both
+// are writer-side only (off the read hot path): the single reload writer pushes
+// retired snapshots and drains those no longer protected by any hazard pointer.
+typedef struct retire_node {
+	conf_acl *          acl;
+	struct retire_node *next;
+} retire_node;
+
+static retire_node *   retire_head = NULL;
+static pthread_mutex_t retire_lock = PTHREAD_MUTEX_INITIALIZER;
+
+// hazard_claim_slot lazily assigns this thread a hazard slot the first time it
+// reads the ACL, remembering the index in thread-local storage. Returns the
+// slot index, or -1 when the fixed-size registry is exhausted.
+static int
+hazard_claim_slot(void)
+{
+	if (t_hazard_index >= 0) {
+		return t_hazard_index;
+	}
+	int idx = __atomic_fetch_add(&hazard_high, 1, __ATOMIC_SEQ_CST);
+	if (idx >= ACL_HAZARD_MAX) {
+		// Undo the over-increment so the high-water mark stays bounded by
+		// ACL_HAZARD_MAX for the writer's scan.
+		__atomic_fetch_sub(&hazard_high, 1, __ATOMIC_SEQ_CST);
+		return -1;
+	}
+	t_hazard_index = idx;
+	return idx;
+}
+
+// hazard_is_protected reports whether any reader currently publishes p in its
+// hazard slot. Called only by the writer while draining the retire list.
+static bool
+hazard_is_protected(conf_acl *p)
+{
+	int high = __atomic_load_n(&hazard_high, __ATOMIC_SEQ_CST);
+	if (high > ACL_HAZARD_MAX) {
+		high = ACL_HAZARD_MAX;
+	}
+	for (int i = 0; i < high; i++) {
+		if (__atomic_load_n(&hazard_slots[i], __ATOMIC_SEQ_CST) == p) {
+			return true;
+		}
+	}
+	return false;
+}
+
+// acl_retire pushes old onto the retire list and reclaims every retired
+// snapshot no longer protected by a hazard pointer. Single-writer, so no CAS is
+// needed; the lock only guards the retire list against a hypothetical second
+// caller and keeps the drain self-consistent.
+static void
+acl_retire(conf_acl *old)
+{
+	retire_node *node = malloc(sizeof(*node));
+	if (node == NULL) {
+		// Cannot track it for deferred reclamation; leak rather than risk
+		// freeing a snapshot a reader may still be traversing.
+		log_error("ACL hazard: retire node alloc failed; leaking old ACL");
+		return;
+	}
+	node->acl = old;
+
+	pthread_mutex_lock(&retire_lock);
+	node->next  = retire_head;
+	retire_head = node;
+
+	retire_node **pp = &retire_head;
+	while (*pp != NULL) {
+		retire_node *cur = *pp;
+		if (!hazard_is_protected(cur->acl)) {
+			*pp = cur->next;
+			conf_acl_destroy(cur->acl);
+			free(cur->acl);
+			free(cur);
+		} else {
+			pp = &cur->next;
+		}
+	}
+	pthread_mutex_unlock(&retire_lock);
+}
+
+void
+nmq_acl_hazard_init(conf *config)
+{
+	if (__atomic_load_n(&hazard_ready, __ATOMIC_SEQ_CST)) {
+		return;
+	}
+
+	conf_acl *snap = malloc(sizeof(*snap));
+	if (snap == NULL) {
+		log_error("ACL hazard: initial snapshot alloc failed; ACL "
+		          "reload disabled");
+		return;
+	}
+	// Move the parsed rules into the immutable heap snapshot and detach them
+	// from config->acl so conf_fini() cannot double-free them. Keep
+	// config->acl.enable because callers read it to decide whether to invoke
+	// auth_acl at all.
+	snap->enable     = config->acl.enable;
+	snap->rule_count = config->acl.rule_count;
+	snap->rules      = config->acl.rules;
+
+	config->acl.rule_count = 0;
+	config->acl.rules      = NULL;
+
+	__atomic_store_n(&acl_current, snap, __ATOMIC_SEQ_CST);
+	__atomic_store_n(&hazard_ready, 1, __ATOMIC_SEQ_CST);
+}
+
+conf_acl *
+nmq_acl_hazard_acquire(void)
+{
+	if (!__atomic_load_n(&hazard_ready, __ATOMIC_SEQ_CST)) {
+		return NULL;
+	}
+
+	int idx = hazard_claim_slot();
+	if (idx < 0) {
+		log_error("ACL hazard: slot registry exhausted (max %d); "
+		          "denying to stay memory-safe",
+		    ACL_HAZARD_MAX);
+		return NULL;
+	}
+
+	// Standard hazard-pointer publish-and-recheck: publish the pointer we
+	// intend to traverse, then confirm it is still the live pointer. The
+	// SEQ_CST hazard store followed by the SEQ_CST reload provides the
+	// StoreLoad ordering that stops the writer's publish+scan from racing the
+	// reader's publish. If the writer swapped in between, retry.
+	conf_acl *p;
+	do {
+		p = __atomic_load_n(&acl_current, __ATOMIC_SEQ_CST);
+		__atomic_store_n(&hazard_slots[idx], p, __ATOMIC_SEQ_CST);
+	} while (p != __atomic_load_n(&acl_current, __ATOMIC_SEQ_CST));
+
+	if (p == NULL) {
+		// Nothing published (should not happen post-init); clear and fall
+		// back so the caller does not dereference NULL.
+		__atomic_store_n(&hazard_slots[idx], NULL, __ATOMIC_SEQ_CST);
+	}
+	return p;
+}
+
+void
+nmq_acl_hazard_release(void)
+{
+	int idx = t_hazard_index;
+	if (idx >= 0) {
+		__atomic_store_n(&hazard_slots[idx], NULL, __ATOMIC_SEQ_CST);
+	}
+}
+
+void
+reload_acl_config(conf *config, conf_acl *new_acl)
+{
+	conf_acl *snap = malloc(sizeof(*snap));
+	if (snap == NULL) {
+		log_error("ACL hazard: reload snapshot alloc failed; keeping "
+		          "current ACL");
+		return;
+	}
+	snap->enable     = new_acl->enable;
+	snap->rule_count = new_acl->rule_count;
+	snap->rules      = new_acl->rules;
+
+	// Detach the moved rules so conf_fini(new_conf) does not double-free them.
+	new_acl->rule_count = 0;
+	new_acl->rules      = NULL;
+
+	// Keep the caller-visible enable gate in sync with the reloaded config.
+	config->acl.enable = snap->enable;
+
+	// Single-writer publish: load-then-store, no CAS required.
+	conf_acl *old = __atomic_load_n(&acl_current, __ATOMIC_SEQ_CST);
+	__atomic_store_n(&acl_current, snap, __ATOMIC_SEQ_CST);
+
+	if (old != NULL) {
+		acl_retire(old);
+	}
+}
+
+#endif /* ACL_SUPP */

--- a/nanomq/acl_hazard.c
+++ b/nanomq/acl_hazard.c
@@ -45,6 +45,15 @@ haz_int_fetch_add(int *p, int v)
 	return __atomic_fetch_add(p, v, __ATOMIC_SEQ_CST);
 }
 
+// Release-ordered store for clearing a hazard slot: the writer's scan only
+// needs to never miss a protected pointer; a stale non-NULL read merely
+// delays reclamation to the next retire drain, so no full fence is needed.
+static inline void
+haz_ptr_store_rel(conf_acl **p, conf_acl *v)
+{
+	__atomic_store_n(p, v, __ATOMIC_RELEASE);
+}
+
 #elif defined(_MSC_VER)
 
 #include <intrin.h>
@@ -84,6 +93,14 @@ haz_int_fetch_add(int *p, int v)
 	return (int) _InterlockedExchangeAdd((volatile long *) p, (long) v);
 }
 
+// MSVC has no cheaper release-only store intrinsic; reuse the full-barrier
+// exchange (correct, merely stronger than required).
+static __forceinline void
+haz_ptr_store_rel(conf_acl **p, conf_acl *v)
+{
+	(void) _InterlockedExchangePointer((void *volatile *) p, v);
+}
+
 #else
 #error "acl_hazard.c needs GCC/Clang __atomic builtins or MSVC intrinsics"
 #endif
@@ -91,7 +108,8 @@ haz_int_fetch_add(int *p, int v)
 // Maximum number of ACL readers that may hold a hazard pointer concurrently.
 // This bounds the number of nng worker / callback threads that can be inside
 // auth_acl at the same time. It is intentionally generous; if it is ever
-// exhausted the reader falls back to a memory-safe deny (see acquire) and logs.
+// exhausted the affected thread's ACL checks are denied (fail-safe, see
+// auth_acl) and the exhaustion is logged once per thread.
 #define ACL_HAZARD_MAX 1024
 
 // The published pointer to the live, immutable ACL snapshot. Written only by
@@ -105,17 +123,29 @@ static int hazard_ready = 0;
 
 // Per-reader hazard slots. A reader publishes the snapshot it is traversing
 // into its own slot; the writer scans all claimed slots before reclaiming a
-// retired snapshot. A reader only ever writes its OWN slot, so reader cores do
-// not share a written cache line (unlike an rwlock reader counter).
-static conf_acl *hazard_slots[ACL_HAZARD_MAX];
+// retired snapshot. A reader only ever writes its OWN slot, and each slot is
+// padded out to a cache line so concurrently-active readers (who claim
+// adjacent indices) never write-share a line (unlike an rwlock reader
+// counter).
+typedef struct {
+	conf_acl *ptr;
+	char      pad[64 - sizeof(conf_acl *)];
+} hazard_slot;
+
+static hazard_slot hazard_slots[ACL_HAZARD_MAX];
 
 // High-water mark of claimed slots; the writer only needs to scan this many.
 // Monotonically increased atomically; never decreased (threads keep their
 // slot for their lifetime).
 static int hazard_high = 0;
 
-// This thread's claimed slot index, or -1 if it has not claimed one yet.
-static ACL_HAZ_TLS int t_hazard_index = -1;
+// This thread's claimed slot index; HAZARD_INDEX_UNSET before the first claim
+// attempt, HAZARD_INDEX_NONE once the registry was found exhausted (the
+// failure is remembered and logged once per thread, keeping the repeated
+// atomic RMW and the log call off the per-message hot path).
+#define HAZARD_INDEX_UNSET -1
+#define HAZARD_INDEX_NONE -2
+static ACL_HAZ_TLS int t_hazard_index = HAZARD_INDEX_UNSET;
 
 // Retire list of replaced snapshots awaiting reclamation, plus its lock. Both
 // are writer-side only (off the read hot path): the single reload writer pushes
@@ -137,11 +167,19 @@ hazard_claim_slot(void)
 	if (t_hazard_index >= 0) {
 		return t_hazard_index;
 	}
+	if (t_hazard_index == HAZARD_INDEX_NONE) {
+		return -1;
+	}
 	int idx = haz_int_fetch_add(&hazard_high, 1);
 	if (idx >= ACL_HAZARD_MAX) {
 		// Undo the over-increment so the high-water mark stays bounded by
-		// ACL_HAZARD_MAX for the writer's scan.
+		// ACL_HAZARD_MAX for the writer's scan, and remember the failure so
+		// this thread neither repeats the RMW nor logs again.
 		haz_int_fetch_add(&hazard_high, -1);
+		t_hazard_index = HAZARD_INDEX_NONE;
+		log_error("ACL hazard: slot registry exhausted (max %d); ACL "
+		          "checks on this thread will be denied",
+		    ACL_HAZARD_MAX);
 		return -1;
 	}
 	t_hazard_index = idx;
@@ -158,7 +196,7 @@ hazard_is_protected(conf_acl *p)
 		high = ACL_HAZARD_MAX;
 	}
 	for (int i = 0; i < high; i++) {
-		if (haz_ptr_load(&hazard_slots[i]) == p) {
+		if (haz_ptr_load(&hazard_slots[i].ptr) == p) {
 			return true;
 		}
 	}
@@ -200,6 +238,26 @@ acl_retire(conf_acl *old)
 	nng_mtx_unlock(retire_mtx);
 }
 
+// acl_snapshot_take moves src's rules into a freshly-allocated immutable heap
+// snapshot and detaches them from src (rule_count/rules cleared) so the source
+// conf's conf_fini cannot double-free them. src->enable is copied but left set
+// on src. Returns NULL when the allocation fails, leaving src untouched.
+static conf_acl *
+acl_snapshot_take(conf_acl *src)
+{
+	conf_acl *snap = malloc(sizeof(*snap));
+	if (snap == NULL) {
+		return NULL;
+	}
+	snap->enable     = src->enable;
+	snap->rule_count = src->rule_count;
+	snap->rules      = src->rules;
+
+	src->rule_count = 0;
+	src->rules      = NULL;
+	return snap;
+}
+
 void
 nmq_acl_hazard_init(conf *config)
 {
@@ -213,22 +271,15 @@ nmq_acl_hazard_init(conf *config)
 		return;
 	}
 
-	conf_acl *snap = malloc(sizeof(*snap));
+	// Move the parsed rules into the immutable heap snapshot; config->acl
+	// keeps only the enable gate, which callers read to decide whether to
+	// invoke auth_acl at all.
+	conf_acl *snap = acl_snapshot_take(&config->acl);
 	if (snap == NULL) {
 		log_error("ACL hazard: initial snapshot alloc failed; ACL "
 		          "reload disabled");
 		return;
 	}
-	// Move the parsed rules into the immutable heap snapshot and detach them
-	// from config->acl so conf_fini() cannot double-free them. Keep
-	// config->acl.enable because callers read it to decide whether to invoke
-	// auth_acl at all.
-	snap->enable     = config->acl.enable;
-	snap->rule_count = config->acl.rule_count;
-	snap->rules      = config->acl.rules;
-
-	config->acl.rule_count = 0;
-	config->acl.rules      = NULL;
 
 	haz_ptr_store(&acl_current, snap);
 	haz_int_store(&hazard_ready, 1);
@@ -243,9 +294,8 @@ nmq_acl_hazard_acquire(void)
 
 	int idx = hazard_claim_slot();
 	if (idx < 0) {
-		log_error("ACL hazard: slot registry exhausted (max %d); "
-		          "denying to stay memory-safe",
-		    ACL_HAZARD_MAX);
+		// Exhaustion was already logged once by hazard_claim_slot; the
+		// caller denies (see auth_acl).
 		return NULL;
 	}
 
@@ -257,13 +307,13 @@ nmq_acl_hazard_acquire(void)
 	conf_acl *p;
 	do {
 		p = haz_ptr_load(&acl_current);
-		haz_ptr_store(&hazard_slots[idx], p);
+		haz_ptr_store(&hazard_slots[idx].ptr, p);
 	} while (p != haz_ptr_load(&acl_current));
 
 	if (p == NULL) {
 		// Nothing published (should not happen post-init); clear and fall
 		// back so the caller does not dereference NULL.
-		haz_ptr_store(&hazard_slots[idx], NULL);
+		haz_ptr_store_rel(&hazard_slots[idx].ptr, NULL);
 	}
 	return p;
 }
@@ -279,7 +329,7 @@ nmq_acl_hazard_release(void)
 {
 	int idx = t_hazard_index;
 	if (idx >= 0) {
-		haz_ptr_store(&hazard_slots[idx], NULL);
+		haz_ptr_store_rel(&hazard_slots[idx].ptr, NULL);
 	}
 }
 
@@ -295,19 +345,12 @@ reload_acl_config(conf *config, conf *new_conf)
 		return;
 	}
 
-	conf_acl *snap = malloc(sizeof(*snap));
+	conf_acl *snap = acl_snapshot_take(&new_conf->acl);
 	if (snap == NULL) {
 		log_error("ACL hazard: reload snapshot alloc failed; keeping "
 		          "current ACL");
 		return;
 	}
-	snap->enable     = new_conf->acl.enable;
-	snap->rule_count = new_conf->acl.rule_count;
-	snap->rules      = new_conf->acl.rules;
-
-	// Detach the moved rules so conf_fini(new_conf) does not double-free them.
-	new_conf->acl.rule_count = 0;
-	new_conf->acl.rules      = NULL;
 
 	// The no-match policy and deny action are companions of the rules (same
 	// auth config block) but are evaluated live from config by auth_acl and

--- a/nanomq/acl_hazard.c
+++ b/nanomq/acl_hazard.c
@@ -179,6 +179,12 @@ nmq_acl_hazard_acquire(void)
 	return p;
 }
 
+bool
+nmq_acl_hazard_ready(void)
+{
+	return __atomic_load_n(&hazard_ready, __ATOMIC_SEQ_CST) != 0;
+}
+
 void
 nmq_acl_hazard_release(void)
 {
@@ -189,7 +195,7 @@ nmq_acl_hazard_release(void)
 }
 
 void
-reload_acl_config(conf *config, conf_acl *new_acl)
+reload_acl_config(conf *config, conf *new_conf)
 {
 	// If startup init never published a snapshot, readers are on the
 	// config-embedded fallback ACL and would never see this reload; no-op so
@@ -206,20 +212,27 @@ reload_acl_config(conf *config, conf_acl *new_acl)
 		          "current ACL");
 		return;
 	}
-	snap->enable     = new_acl->enable;
-	snap->rule_count = new_acl->rule_count;
-	snap->rules      = new_acl->rules;
+	snap->enable     = new_conf->acl.enable;
+	snap->rule_count = new_conf->acl.rule_count;
+	snap->rules      = new_conf->acl.rules;
 
 	// Detach the moved rules so conf_fini(new_conf) does not double-free them.
-	new_acl->rule_count = 0;
-	new_acl->rules      = NULL;
+	new_conf->acl.rule_count = 0;
+	new_conf->acl.rules      = NULL;
 
-	// Keep the caller-visible enable gate in sync with the reloaded config.
-	config->acl.enable = snap->enable;
+	// The no-match policy and deny action are companions of the rules (same
+	// auth config block) but are evaluated live from config by auth_acl and
+	// the pub/sub handlers, so reload them together with the rules.
+	config->acl_nomatch     = new_conf->acl_nomatch;
+	config->acl_deny_action = new_conf->acl_deny_action;
 
 	// Single-writer publish: load-then-store, no CAS required.
 	conf_acl *old = __atomic_load_n(&acl_current, __ATOMIC_SEQ_CST);
 	__atomic_store_n(&acl_current, snap, __ATOMIC_SEQ_CST);
+
+	// Update the caller-visible enable gate only after the snapshot is live,
+	// so a reader that passes a newly-enabled gate always finds the new rules.
+	config->acl.enable = snap->enable;
 
 	if (old != NULL) {
 		acl_retire(old);

--- a/nanomq/acl_hazard.c
+++ b/nanomq/acl_hazard.c
@@ -191,6 +191,15 @@ nmq_acl_hazard_release(void)
 void
 reload_acl_config(conf *config, conf_acl *new_acl)
 {
+	// If startup init never published a snapshot, readers are on the
+	// config-embedded fallback ACL and would never see this reload; no-op so
+	// the enable gate and the rules readers traverse stay consistent.
+	if (!__atomic_load_n(&hazard_ready, __ATOMIC_SEQ_CST)) {
+		log_error("ACL hazard: registry not initialized; skipping ACL "
+		          "reload");
+		return;
+	}
+
 	conf_acl *snap = malloc(sizeof(*snap));
 	if (snap == NULL) {
 		log_error("ACL hazard: reload snapshot alloc failed; keeping "

--- a/nanomq/apps/broker.c
+++ b/nanomq/apps/broker.c
@@ -37,6 +37,7 @@
 #include "nng/protocol/pubsub0/pub.h"
 
 #include "include/acl_handler.h"
+#include "include/acl_hazard.h"
 #include "include/bridge.h"
 #include "include/nng_bridge.h"
 #include "include/nanomq_rule.h"
@@ -949,6 +950,13 @@ broker(conf *nanomq_conf)
 	// add the num of other proto
 	nanomq_conf->total_ctx = nanomq_conf->parallel;		// match with num of aio
 	num_work = nanomq_conf->parallel;					// match with num of works
+
+#ifdef ACL_SUPP
+	// Publish the initial ACL snapshot and initialize the hazard registry
+	// once, before any worker context can call auth_acl, so `nanomq reload`
+	// can swap the ACL lock-free without racing readers.
+	nmq_acl_hazard_init(nanomq_conf);
+#endif
 
 
 #if defined(SUPP_RULE_ENGINE)

--- a/nanomq/cmd_proc.c
+++ b/nanomq/cmd_proc.c
@@ -7,6 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include "include/acl_hazard.h"
 #include "include/cmd_proc.h"
 #include "include/conf_api.h"
 #include "include/nanomq.h"
@@ -86,6 +87,9 @@ handle_recv(const char *msg, size_t msg_len, conf *config, char **err_msg)
 	reload_basic_config(config, new_conf);
 	reload_sqlite_config(&config->sqlite, &new_conf->sqlite);
 	reload_auth_config(&config->auths, &new_conf->auths);
+#ifdef ACL_SUPP
+	reload_acl_config(config, &new_conf->acl);
+#endif
 	reload_log_config(config, new_conf);
 
 

--- a/nanomq/cmd_proc.c
+++ b/nanomq/cmd_proc.c
@@ -88,7 +88,7 @@ handle_recv(const char *msg, size_t msg_len, conf *config, char **err_msg)
 	reload_sqlite_config(&config->sqlite, &new_conf->sqlite);
 	reload_auth_config(&config->auths, &new_conf->auths);
 #ifdef ACL_SUPP
-	reload_acl_config(config, &new_conf->acl);
+	reload_acl_config(config, new_conf);
 #endif
 	reload_log_config(config, new_conf);
 

--- a/nanomq/include/acl_hazard.h
+++ b/nanomq/include/acl_hazard.h
@@ -35,20 +35,31 @@ extern void nmq_acl_hazard_init(conf *config);
 // nmq_acl_hazard_acquire returns the current immutable ACL snapshot with this
 // thread's hazard pointer set to it, protecting it from reclamation until
 // nmq_acl_hazard_release is called. Returns NULL when the registry is not yet
-// initialized or when no hazard slot is available; the caller must then fall
-// back to a memory-safe path (never traverse the live pointer unprotected).
+// initialized or when no hazard slot is available; the caller must then choose
+// a memory-safe path (never traverse the live pointer unprotected): before
+// init the rules still live in config->acl, after init only the snapshot
+// holds them, so consult nmq_acl_hazard_ready to pick fallback vs deny.
 extern conf_acl *nmq_acl_hazard_acquire(void);
+
+// nmq_acl_hazard_ready reports whether the registry has published a snapshot
+// (i.e. the rules have been moved out of config->acl). Lets auth_acl tell a
+// pre-init acquire failure (config->acl still authoritative) from a
+// post-init one (config->acl is empty; fail safe by denying).
+extern bool nmq_acl_hazard_ready(void);
 
 // nmq_acl_hazard_release clears this thread's hazard pointer. It MUST be called
 // on every auth_acl exit path once acquire has been called.
 extern void nmq_acl_hazard_release(void);
 
-// reload_acl_config publishes new_acl as the new immutable snapshot and retires
-// the previous one, reclaiming it once no reader still protects it. The rules
-// are moved out of new_acl (rule_count/rules cleared) so the caller's
-// conf_fini(new_conf) does not double-free them. config->acl.enable is updated
-// so callers observe an enable/disable change made during reload.
-extern void reload_acl_config(conf *config, conf_acl *new_acl);
+// reload_acl_config publishes new_conf's ACL as the new immutable snapshot and
+// retires the previous one, reclaiming it once no reader still protects it.
+// The rules are moved out of new_conf->acl (rule_count/rules cleared) so the
+// caller's conf_fini(new_conf) does not double-free them. The companion policy
+// fields acl_nomatch and acl_deny_action are copied into config (auth_acl and
+// the pub/sub handlers evaluate them live), and config->acl.enable is updated
+// after the snapshot is published so a reader passing a newly-enabled gate
+// always finds the new rules.
+extern void reload_acl_config(conf *config, conf *new_conf);
 
 #endif /* ACL_SUPP */
 #endif /* NANOMQ_ACL_HAZARD_H */

--- a/nanomq/include/acl_hazard.h
+++ b/nanomq/include/acl_hazard.h
@@ -1,0 +1,54 @@
+#ifndef NANOMQ_ACL_HAZARD_H
+#define NANOMQ_ACL_HAZARD_H
+
+#ifdef ACL_SUPP
+
+#include "nng/supplemental/nanolib/acl_conf.h"
+#include "nng/supplemental/nanolib/conf.h"
+
+// Lock-free, hazard-pointer-based publication of the live ACL.
+//
+// The ACL (the set of parse rules used by auth_acl) is read on the hot path by
+// every publish and subscribe, and rewritten wholesale by `nanomq reload`.
+// Instead of guarding the read path with an rwlock (whose rdlock performs a
+// read-modify-write on a shared reader counter and therefore bounces that
+// cache line between every reader core), the live ACL is published through a
+// single atomically-swapped pointer to an immutable conf_acl. Readers load the
+// pointer once and traverse that immutable snapshot; the only shared write a
+// reader performs is to its OWN hazard slot, so reader cores never contend on a
+// shared cache line.
+//
+// Reclamation of a replaced ACL is deferred until no reader still holds a
+// hazard pointer to it (hazard-pointer safe memory reclamation). Reload is
+// single-writer (the cmd server processes one reload at a time), so the writer
+// may load-then-store the published pointer without a CAS.
+
+// nmq_acl_hazard_init installs the ACL parsed into config->acl as the first
+// immutable snapshot and initializes the hazard registry. It must be called
+// exactly once at broker startup, before any worker context can call auth_acl.
+// It takes ownership of config->acl.rules (moving them into the heap snapshot)
+// and detaches them from config->acl so conf_fini() cannot double-free them;
+// config->acl.enable is left intact because callers still read it to gate the
+// auth_acl call.
+extern void nmq_acl_hazard_init(conf *config);
+
+// nmq_acl_hazard_acquire returns the current immutable ACL snapshot with this
+// thread's hazard pointer set to it, protecting it from reclamation until
+// nmq_acl_hazard_release is called. Returns NULL when the registry is not yet
+// initialized or when no hazard slot is available; the caller must then fall
+// back to a memory-safe path (never traverse the live pointer unprotected).
+extern conf_acl *nmq_acl_hazard_acquire(void);
+
+// nmq_acl_hazard_release clears this thread's hazard pointer. It MUST be called
+// on every auth_acl exit path once acquire has been called.
+extern void nmq_acl_hazard_release(void);
+
+// reload_acl_config publishes new_acl as the new immutable snapshot and retires
+// the previous one, reclaiming it once no reader still protects it. The rules
+// are moved out of new_acl (rule_count/rules cleared) so the caller's
+// conf_fini(new_conf) does not double-free them. config->acl.enable is updated
+// so callers observe an enable/disable change made during reload.
+extern void reload_acl_config(conf *config, conf_acl *new_acl);
+
+#endif /* ACL_SUPP */
+#endif /* NANOMQ_ACL_HAZARD_H */


### PR DESCRIPTION
## Apply ACL-file changes on `nanomq reload`, lock-free

Fixes #2373.

`nanomq reload` re-reads basic/sqlite/auth/log config but never re-reads the
ACL: `reload_auth_config` exists, `reload_acl_config` did not. So an `allow`
rule added to the ACL file only takes effect on a full restart — `reload`
reports `reload succeed!` while silently applying only the password half.

### Why this is lock-free (addressing the data-race concern raised on #2373)

The ACL (`config->acl`) is read on the hot path by `auth_acl()` for **every**
publish and subscribe, and `reload` rewrites it wholesale. A naive swap is a
use-after-free (a reader traversing `config->acl.rules` while reload frees that
array). The obvious fix — an rwlock around `auth_acl` — would put a shared
reader-counter RMW on the hottest path in the broker, whose cache line then
bounces exclusively between every reader core. That is exactly the cost worth
avoiding.

This PR instead makes the live ACL an **atomically-published immutable object**
reclaimed with **hazard pointers**:

- **Reader** (`auth_acl`): one atomic load of the published pointer + a write to
  the calling thread's **own** hazard slot (publish-and-recheck). No shared
  atomic, no lock, no cross-core cache-line bouncing. The slot is cleared on
  every return path. *(Edit: hazard slots are now each padded to a cache line,
  so adjacent readers' slots never write-share one, and the clear is
  release-ordered.)*
- **Writer** (`reload_acl_config`, single-writer — the cmd server serializes
  reloads): parse the new ACL, publish the new pointer, then scan the hazard
  slots; free the old ACL immediately if unreferenced, else retire it and drain
  the retire list on the next reload. Load-then-store is sufficient (no CAS)
  because reload is single-writer.
- ~~The config-embedded ACL remains a safe fallback for the pre-init / slot-exhaustion window.~~
  *Edit:* before init the config-embedded ACL (which still holds the boot
  rules) is the fallback; after init the rules live only in the snapshot, so an
  acquire failure (slot exhaustion) **denies** rather than silently falling
  through to the `no_match` policy (fail-safe).

*Edit:* reload now also applies the companion policy fields `no_match` and
`deny_action` together with the rules; they are evaluated live by `auth_acl`
and the pub/sub handlers, so swapping only the rules would run them under a
stale policy.

Everything lives in nanomq-owned files (`acl_hazard.c/.h`); the nng submodule is
untouched.

### Verification

- Builds clean under `-fsanitize=address,undefined`.
- **Stress test** (no docker, ASan binary): 50 `nanomq reload` iterations with
  alternating rule sets, concurrent with 6 publishers + 2 subscribers
  (~1200 msg/s, ~2700 messages, every pub/sub hitting `auth_acl`).
  - ACL changes take effect after reload: a newly-allowed publish is delivered
    to an authorized subscriber; the pre-reload denied publish is blocked.
  - AddressSanitizer/UBSan: **zero** use-after-free / heap-buffer-overflow;
    broker alive and listening at the end.
- *(Edit)* **Policy-reload smoke test**: broker started with a deny-publish
  rule and `no_match = allow`, reloaded to an allow rule with
  `no_match = deny`, with long-lived subscribers across the reload. Pre-reload
  the denied publish is blocked and an unmatched topic delivered; post-reload
  the newly-allowed publish is delivered and the unmatched topic blocked (both
  the rule swap and the `no_match` swap take effect).

### Known caveat — portability

<del>To array the hazard slots this uses GCC/Clang `__atomic` builtins on plain
pointers plus `__thread`, because `nni_atomic_ptr` is an opaque struct (defined
only in nng's private `posix_impl.h`) that can't be arrayed without reaching
into nng internals, and the project compiles at C99 (no `<stdatomic.h>`). This
is correct on GCC/Clang but needs an MSVC shim (`__declspec(thread)` +
`_Interlocked*`/`<stdatomic.h>`) for the Windows build. I'm happy to add that
layer if you'd take the change — wanted to get the design in front of you
first.</del>

*Edit: resolved.* The MSVC shim is now included: the atomic and TLS primitives
are wrapped once per compiler (GCC/Clang `__atomic` builtins + `__thread`;
MSVC Interlocked intrinsics, which are full-barrier so every SEQ_CST
requirement of the protocol is met, + `__declspec(thread)`), and the
retire-list lock now uses the public portable `nng_mtx`. A shim is still
needed rather than `nng_atomic_ptr` because hazard pointers require an *array*
of per-thread slots plus a thread-local slot index, and nng's public API has
no TLS primitive and no way to array its opaque `nng_atomic_ptr`.

### Related

While testing this I also hit a separate, pre-existing crash: `nanomq reload`
SIGSEGVs in `log_log` when run concurrently with logging (reload tears down the
log callback table that `log_log` reads lock-free). Filed as #2375; it is
independent of the ACL path and reproduces on `master`.

An alternative implementation using a plain rwlock (simpler, ~80 lines, but with
the hot-path shared-atomic cost described above) is available if you'd prefer to
weigh the tradeoff:
https://github.com/nanomq/nanomq/compare/master...jayenashar:feat/reload-acl


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ACL rule evaluation during configuration reloads.
  * Prevented authorization checks from using inconsistent or prematurely released ACL data.
  * Added safer handling when ACL topic substitution fails.

* **Enhancements**
  * ACL updates can now be applied more safely while the broker is running, reducing authorization errors and reload-related instability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
