### PR TITLE
fix(conf): set max_topic_alias in default and CI configs

### DIFF
--- a/.github/scripts/nanomq.conf
+++ b/.github/scripts/nanomq.conf
@@ -6,6 +6,7 @@
 
 mqtt {
     property_size = 32
+    max_topic_alias = 1024
     max_packet_size = 256MB
     max_mqueue_len = 2048
     retry_interval = 10s

--- a/etc/nanomq.conf
+++ b/etc/nanomq.conf
@@ -6,6 +6,7 @@
 
 mqtt {
     property_size = 32
+    max_topic_alias = 1024
     max_packet_size = 256MB
     max_mqueue_len = 2048
     retry_interval = 10s


### PR DESCRIPTION
## Problem

Since #2374, `pub_handler.c` rejects any MQTT v5 PUBLISH whose topic alias exceeds `conf->max_topic_alias`:

```
ERROR pub_handler.c:1668: Invalid Topic Alias: 10 (Server Max allowed: 0). Closing connection or rejecting publish.
```

`max_topic_alias` has no nonzero default (it is only set when the config file provides it), and neither the CI function-test config (`.github/scripts/nanomq.conf`) nor the shipped default config (`etc/nanomq.conf`) sets it. As a result the broker advertises Topic Alias Maximum 0 in CONNACK and rejects every topic-alias publish.

This broke the Function test workflow on master itself (mqtt v5 topic alias test), starting with the push that merged #2374: https://github.com/nanomq/nanomq/actions/runs/29245583768 — and every branch/PR run since fails the same way. It also breaks real MQTT v5 clients that use topic aliases against the default config.

## Fix

Set `max_topic_alias = 1024` in the `mqtt {}` block of both configs, matching the documented value in `etc/nanomq_example.conf`.

## Verification

Reproduced locally against a master build (`6fd7e02`), mirroring the CI test:

- Without `max_topic_alias`: `mosquitto_pub -V 5 -D Publish topic-alias 10 -q 1` gets `DISCONNECT (128)` on repeat publishes; subscriber receives 0/3 messages (identical to the CI failure output).
- With `max_topic_alias = 1024`: all 3 publishes return rc=0 and the subscriber receives 3/3 messages.

## Note

A config-file entry only papers over the default. You may also want a nonzero default for `max_topic_alias` in `conf_init` (NanoNNG) so that behavior with a minimal config matches the pre-#2374 behavior; happy to send that PR too if you agree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum supported MQTT topic aliases to 1,024.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->