### PR TITLE
* FIX [cli] Sleep 500ms before pub cli exit & Fixed a compile warning missing header file.

### DIFF
--- a/nanomq/tests/quic_smoke_test.c
+++ b/nanomq/tests/quic_smoke_test.c
@@ -22,6 +22,7 @@
 #include <nng/mqtt/mqtt_quic_client.h>
 #include <nng/mqtt/mqtt_client.h>
 #include <nng/supplemental/nanolib/log.h>
+#include <nng/protocol/mqtt/mqtt_parser.h>
 
 #define TEST_MQTT_QUIC_URL "mqtt-quic://127.0.0.1:14567"
 #define TEST_MQTT_QUIC_TOPIC "nanomq/quic/test"

--- a/nanomq_cli/client.c
+++ b/nanomq_cli/client.c
@@ -1571,6 +1571,7 @@ client_cb(void *arg)
 				work->state = SEND_WAIT;
 				nng_sleep_aio(work->opts->interval, work->aio);
 			} else {
+				nng_msleep(500);
 				nng_socket_close(*work->sock);
 				exit(1);
 			}
@@ -1705,7 +1706,7 @@ quic_connect_cb(void *rmsg, void *arg)
 	struct connect_param *param  = arg;
 	int                   reason = 0;
 
-	console("%s: %s connect\n", __FUNCTION__, param->opts->url);
+	console("%s: %s connected\n", __FUNCTION__, param->opts->url);
 
 	if (reason == 0) {
 		if (param->opts->type == SUB && param->opts->topic_count > 0) {
@@ -1726,7 +1727,6 @@ quic_connect_cb(void *rmsg, void *arg)
 			    topics_qos, param->opts->topic_count);
 		}
 	}
-
 
 	return 0;
 }


### PR DESCRIPTION
… 
With this PR https://github.com/nanomq/NanoNNG/pull/1478. Try to fix https://github.com/nanomq/nanomq/issues/2242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for publishing and subscribing over non-interactive connections by allowing a brief delay before shutdown.
  * Updated QUIC connection status messaging for clearer feedback.
* **Tests**
  * Improved QUIC smoke-test support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->