### PR TITLE
* DOC add new docs about reload log level

### DIFF
--- a/docs/en_US/config-description/logs.md
+++ b/docs/en_US/config-description/logs.md
@@ -23,7 +23,7 @@ log = {
   - `file`: Write logs to a file.
   - `console`: Write logs to standard I/O
   - `syslog`: Write logs to syslog
-- `level`: Specifies the log level. Only messages with a severity level equal to or higher than this level will be logged. Optional values:
+- `level`: Specifies the log level. Only messages with a severity level equal to or higher than this level will be logged. Only log level support hot update with `nanomq reload --conf` command. Logging target, file path is not changable with reload command. Optional values:
   - `trace`
   - `debug`
   - `info`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that log levels can be updated without restarting via `nanomq reload --conf`.
  * Noted that logging targets and paths cannot be changed using the reload command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->