### PR TITLE
* FIX [acl] include clientid, username and topic in acl deny log

### DIFF
--- a/nanomq/pub_handler.c
+++ b/nanomq/pub_handler.c
@@ -1712,7 +1712,14 @@ handle_pub(nano_work *work, struct pipe_content *pipe_ct, uint8_t proto,
 			bool rv = auth_acl(
 			    work->config, ACL_PUB, work->cparam, topic);
 			if (!rv) {
-				log_warn("acl deny");
+				const char *cid = (const char *)
+				    conn_param_get_clientid(work->cparam);
+				const char *username = (const char *)
+				    conn_param_get_username(work->cparam);
+				log_warn("acl deny publish clientid [%s] "
+				         "username [%s] topic [%s]",
+				    cid == NULL ? "" : cid,
+				    username == NULL ? "" : username, topic);
 				if (work->config->acl_deny_action ==
 				    ACL_DISCONNECT) {
 					log_warn(

--- a/nanomq/sub_handler.c
+++ b/nanomq/sub_handler.c
@@ -418,7 +418,15 @@ sub_ctx_handle(nano_work *work)
 			bool auth_result = auth_acl(
 			    work->config, ACL_SUB, work->cparam, topic_str);
 			if (!auth_result) {
-				log_warn("acl deny");
+				const char *cid = (const char *)
+				    conn_param_get_clientid(work->cparam);
+				const char *username = (const char *)
+				    conn_param_get_username(work->cparam);
+				log_warn("acl deny subscribe clientid [%s] "
+				         "username [%s] topic [%s]",
+				    cid == NULL ? "" : cid,
+				    username == NULL ? "" : username,
+				    topic_str);
 				tn->reason_code = NMQ_AUTH_SUB_ERROR;
 				if (work->config->acl_deny_action ==
 				    ACL_DISCONNECT) {


### PR DESCRIPTION
Fixes #2384.

ACL deny was logged as a bare `log_warn("acl deny")` on both the publish path (`nanomq/pub_handler.c`) and the subscribe path (`nanomq/sub_handler.c`), while "acl allow" is `log_debug`. At warn level an operator could see that a deny happened but had no way to tell which client, username, or topic was denied.

This PR includes the client id, username, and denied topic in the deny warn line on both paths. All three values are already available at the call sites: the topic is the one passed to `auth_acl`, and the identity comes from `conn_param_get_clientid` / `conn_param_get_username` on `work->cparam`. A NULL username (anonymous client) renders as empty brackets.

Log output before:

```
WARN  .../nanomq/pub_handler.c:1715 handle_pub: acl deny
```

after:

```
WARN  .../nanomq/pub_handler.c:1719 handle_pub: acl deny publish clientid [test-client-1] username [alice] topic [denied/foo]
WARN  .../nanomq/sub_handler.c:425 sub_ctx_handle: acl deny subscribe clientid [test-client-2] username [bob] topic [denied/bar]
WARN  .../nanomq/pub_handler.c:1719 handle_pub: acl deny publish clientid [anon-client] username [] topic [denied/anon]
```

Tested by building with `-DENABLE_ACL=ON`, running the broker with an ACL that denies `denied/#` for publish and subscribe, and exercising a denied publish, a denied subscribe, and a denied anonymous publish with mosquitto clients; the lines above are from that run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access-control denial warnings by including the client ID, username, and denied topic for rejected publish and subscribe requests.
  * Preserved clear logging when client identity details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->