### PR TITLE
* NEW [log] log publisher clientid and username in per-message debug lines

### DIFF
--- a/nanomq/pub_handler.c
+++ b/nanomq/pub_handler.c
@@ -2077,6 +2077,18 @@ decode_pub_message(nano_work *work, uint8_t proto)
 	nng_msg                  *msg        = work->msg;
 	struct pub_packet_struct *pub_packet = work->pub_packet;
 
+	// publisher identity for per-message log attribution
+	const char *clientid = work->cparam == NULL
+	    ? NULL
+	    : (const char *) conn_param_get_clientid(work->cparam);
+	const char *username = work->cparam == NULL
+	    ? NULL
+	    : (const char *) conn_param_get_username(work->cparam);
+	if (clientid == NULL)
+		clientid = "";
+	if (username == NULL)
+		username = "";
+
 	uint8_t *msg_body = nng_msg_body(msg);
 	size_t   msg_len  = nng_msg_len(msg);
 
@@ -2134,11 +2146,12 @@ decode_pub_message(nano_work *work, uint8_t proto)
 
 		// TODO if topic_len = 0 && mqtt_version = 5.0, search topic alias from nano_db
 
-		log_debug("topic: [%.*s], len: [%d], qos: %d",
+		log_debug("topic: [%.*s], len: [%d], qos: %d, "
+		          "clientid: [%s], username: [%s]",
 		    pub_packet->var_header.publish.topic_name.len,
 		    pub_packet->var_header.publish.topic_name.body,
 			pub_packet->var_header.publish.topic_name.len,
-		    pub_packet->fixed_header.qos);
+		    pub_packet->fixed_header.qos, clientid, username);
 
 		if (pub_packet->fixed_header.qos > 0) {
 			if (pos + 2 > msg_len) {
@@ -2204,8 +2217,10 @@ decode_pub_message(nano_work *work, uint8_t proto)
 			memcpy(pub_packet->payload.data,
 			    (uint8_t *) (msg_body + pos),
 			    pub_packet->payload.len);
-			log_debug("payload: [%s], len = %u",
-			    pub_packet->payload.data, pub_packet->payload.len);
+			log_debug("payload: [%s], len = %u, "
+			          "clientid: [%s], username: [%s]",
+			    pub_packet->payload.data, pub_packet->payload.len,
+			    clientid, username);
 		}
 		break;
 


### PR DESCRIPTION
Closes #2386.

### Problem
At debug log level, `decode_pub_message` logs each published message's topic and payload, but neither line identifies the publishing client. Operators have to correlate these lines with separate connect/disconnect events by timestamp and worker thread id to attribute a message.

### Solution
Read the client id and username once from `work->cparam` (`conn_param_get_clientid` / `conn_param_get_username`) and append `clientid: [...]`, `username: [...]` to the existing topic and payload debug lines. Both fields fall back to empty strings when `cparam` is absent (bridge and test call paths reach the decoder without connection params, and the accessors dereference `cparam` unchecked) or when the client connected without a username.

### Verification
Built with cmake and ran the broker locally at `--log_level debug`, publishing with mosquitto_pub:

```
DEBUG ... decode_pub_message: topic: [sensors/gps], len: [11], qos: 0, clientid: [drone-42], username: [pilot-alice]
DEBUG ... decode_pub_message: payload: [{"lat":1.23}], len = 12, clientid: [drone-42], username: [pilot-alice]
```

An anonymous publish logs `username: []`, and internal `$SYS` connect/disconnect event messages pick up the originating client's identity through the same path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Logging Improvements**
  * Enhanced publish-message debug logs with client and username details.
  * Improved traceability when reviewing decoded message activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->