### PR TITLE
* FIX [ci] authenticate latest-tag lookup to avoid anonymous rate limit

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -124,8 +124,10 @@ jobs:
         else
           # Authenticate to avoid the anonymous rate limit shared by all
           # Actions runners on this IP, which intermittently returns an error
-          # object that jq then fails to index as an array
-          LATEST_TAG="$(curl -s --retry 3 -H "Authorization: Bearer ${{ github.token }}" "https://api.github.com/repos/nanomq/nanomq/tags?per_page=1" | jq -r '.[0].name')"
+          # object that jq then fails to index as an array. The || true keeps
+          # a curl/jq failure on the explicit error path below instead of
+          # aborting the step via pipefail before it can report.
+          LATEST_TAG="$(curl -fsS --retry 3 -H "Authorization: Bearer ${{ github.token }}" "https://api.github.com/repos/nanomq/nanomq/tags?per_page=1" | jq -r '.[0].name' || true)"
         fi
         if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" == "null" ]; then
           echo "Failed to resolve the latest tag from the GitHub API" >&2

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -122,7 +122,14 @@ jobs:
         if [ "${{ github.event_name }}" == "release" ]; then
           LATEST_TAG="${{ github.ref_name }}"
         else
-          LATEST_TAG="$(curl -s "https://api.github.com/repos/nanomq/nanomq/tags?per_page=1" | jq -r '.[0].name')"
+          # Authenticate to avoid the anonymous rate limit shared by all
+          # Actions runners on this IP, which intermittently returns an error
+          # object that jq then fails to index as an array
+          LATEST_TAG="$(curl -s --retry 3 -H "Authorization: Bearer ${{ github.token }}" "https://api.github.com/repos/nanomq/nanomq/tags?per_page=1" | jq -r '.[0].name')"
+        fi
+        if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" == "null" ]; then
+          echo "Failed to resolve the latest tag from the GitHub API" >&2
+          exit 1
         fi
         echo "LATEST_TAG: $LATEST_TAG"
         echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

`Build packages` matrix jobs fail randomly (a different arch each run) in the **Get latest tag** step with:

```
jq: error (at <stdin>:1): Cannot index object with number
##[error]Process completed with exit code 5.
```

The step queries `https://api.github.com/repos/nanomq/nanomq/tags` anonymously. GitHub Actions runners share egress IPs, so the anonymous rate limit (60 requests/hour/IP) is frequently exhausted; the API then returns an error **object** (`{"message": "API rate limit exceeded..."}`) instead of an array, and `jq -r '.[0].name'` fails. With ~40 matrix jobs hitting the API at once, at least one job usually loses the lottery.

## Fix

* Authenticate the request with the workflow's `github.token` (5,000 requests/hour per repository, no shared-IP lottery).
* Add `curl --retry 3` for transient network errors.
* Fail the step with a clear message if the tag still cannot be resolved, instead of propagating `null` into the package name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability when retrieving the latest tag by adding authenticated API access and automatic retries.
  * Preserved existing validation and release workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->