### PR TITLE
FIX [broker] reset MQTT v5 topic aliases at CONNACK instead of on the disconnect event

### DIFF
--- a/nanomq/apps/broker.c
+++ b/nanomq/apps/broker.c
@@ -515,6 +515,13 @@ server_cb(void *arg)
 		} else if (work->flag == CMD_CONNACK) {
 			uint8_t *body        = nng_msg_body(work->msg);
 			uint8_t  reason_code = *(body + 1);
+			// MQTT v5 topic aliases are per-connection state. Reset
+			// them here, before the CONNACK is sent, rather than on
+			// DISCONNECT_EV: the disconnect event is processed
+			// concurrently with publishes that are still queued on
+			// other worker ctxs, so deleting there loses aliased
+			// publishes the transport has already acknowledged.
+			dbhash_del_atpair_queue(work->pid.id);
 			if (work->proto == PROTO_MQTT_BROKER) {
 				// Return CONNACK to clients of broker
 				nng_aio_set_prov_data(work->aio, &work->pid.id);
@@ -549,8 +556,9 @@ server_cb(void *arg)
 			if (dbhash_check_id(work->pid.id)) {
 				destroy_sub_client(work->pid.id, work->db);
 			}
-			// delete topic alias
-			dbhash_del_atpair_queue(work->pid.id);
+			// topic aliases are reset at the next CONNACK for this
+			// pipe id; deleting them here would race publishes from
+			// this connection still queued on other worker ctxs
 			// bridge's will msg only valid at remote
 			if (work->proto != PROTO_MQTT_BRIDGE) {
 				if (conn_param_get_will_flag(work->cparam) == 0 ||


### PR DESCRIPTION
## Symptom

The Function test suite intermittently fails the TLS v5 stage on slow (ASAN, 2-vCPU) runners: the topic-alias subscriber receives 2/10 or 9/10 messages, `mosquitto_pub` reports `The client is not currently connected`, and the broker log shows

```
ERROR nanomq/pub_handler.c:1690: could not find topic by alias: 10
WARN  nng/src/sp/protocol/mqtt/nmq_mqtt.c:414: pipe id <publisher> is gone, pub failed
```

Failing runs on the CI fork: `jayenashar/nanomq` actions runs 29626553999 and 29627003769 (tls v5 attempts failing in `test_topic_alias`), each with this exact signature, typically 1-2 s after a burst of disconnect processing (e.g. the 0x8E session-expiry reap).

## Root cause

MQTT v5 topic-alias mappings are stored in a global table keyed by pipe id and were deleted in the `CMD_DISCONNECT_EV` handler (`broker.c`). But:

1. The transport layer PUBACKs a QoS 1 PUBLISH as soon as it is read off the wire, before any app-layer processing. A client that publishes N aliased messages and disconnects after its last PUBACK can therefore disconnect while several of its publishes are still queued for the app-layer worker ctxs.
2. Publishes and the disconnect event are processed concurrently by different worker ctxs, and under ctx saturation the disconnect event can even jump ahead of parked publishes (`nano_ctx_recv` drains `waitlmq` before `recvpipes`).

When the disconnect event won that race, `dbhash_del_atpair_queue()` deleted the publisher's alias mapping while its acknowledged publishes were still in flight. Their alias lookups then failed, the messages were dropped (despite having been PUBACKed), and the broker kicked the (already gone) pipe. The same window also allowed a delayed disconnect event to delete the alias state of a fast-reconnecting client with the same client id.

This is why switching the CI test to QoS 1 (d744ec78) did not cure the flake: PUBACK does not mean "processed" in nanomq, so waiting for PUBACKs before disconnecting does not close the window.

## Fix

Topic aliases are per-connection state (MQTT 5 spec 3.3.2.3.4; they are explicitly not part of session state). Reset them when the connection is established - in the `CMD_CONNACK` handler, before the CONNACK is sent to the client, at which point no publish from that connection can be in flight - instead of on the disconnect event.

Trade-off: the alias vector for a pipe id now persists after disconnect until the next client hashing to that pipe id connects (a few bytes per alias-using client id). In exchange, no publish that the broker has acknowledged can lose its alias mapping.

## Validation (local ASAN build, broker pinned to 2 cores, 4 taskq threads, flood load)

- Unpatched: repeated `could not find topic by alias` errors (2-5 per 100 alias-publisher trials; five in one minute during a burst), matching the CI signature including the trailing `pipe id ... is gone, pub failed`.
- Patched: 0 errors in 520 trials of the same repro.
- Isolation probes (raw-socket v5 client): register-alias -> wait -> burst aliased tail -> hard-close, 200 trials: 0 errors (the disconnect race is gone). Burst-everything-and-hold-open, 200 trials: 0 errors.
- Per-connection semantics kept: a reconnecting client with the same client id does not inherit the previous connection's aliases (stale alias is rejected as before).
- 16 runs of the CI `tls_v5_test.py` stage (adapted ports) against the patched broker: zero topic-alias lookup failures in the broker log.

## Residual note

App-layer publish processing is still not strictly ordered per connection, so an extreme-overload reorder of the alias-registration publish against a later lookup remains theoretically possible (not observed in 400 isolation-probe trials). Fixing that would require per-connection ordering of `handle_pub`, which is out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT v5 topic alias handling when establishing connections.
  * Ensured stale topic aliases are cleared before connection acknowledgment, preventing aliases from carrying over between connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->