### PR TITLE
FIx broken CI Build packages workflow caused by new ver of msquic & ubuntu 20.0 runner is dropped by github

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -22,10 +22,8 @@ jobs:
         arch:
         - [amd64, gcc, g++, x86_64-linux-gnu, /usr/local]
         - [arm64, aarch64-linux-gnu-gcc, aarch64-linux-gnu-g++, aarch64-linux-gnu, /usr/aarch64-linux-gnu]
-        - [mips, mips-linux-gnu-gcc, mips-linux-gnu-g++, mips-linux-gnu, /usr/mips-linux-gnu]
         - [riscv64, riscv64-linux-gnu-gcc, riscv64-linux-gnu-g++, riscv64-linux-gnu, /usr/riscv64-linux-gnu]
         - [armhf, arm-linux-gnueabihf-gcc, arm-linux-gnueabihf-g++, arm-linux-gnueabihf, /usr/arm-linux-gnueabihf]
-        - [armel, arm-linux-gnueabi-gcc, arm-linux-gnueabi-g++, arm-linux-gnueabi, /usr/arm-linux-gnueabi]
         package_type:
         - rpm
         - deb
@@ -35,50 +33,48 @@ jobs:
         - "-msquic"
         - "-full"
         exclude:
-        - arch: [mips, mips-linux-gnu-gcc, mips-linux-gnu-g++]
-          build_type: "-msquic"
         - arch: [riscv64, riscv64-linux-gnu-gcc, riscv64-linux-gnu-g++]
           build_type: "-msquic"
-        - arch: [armel, arm-linux-gnueabi-gcc, arm-linux-gnueabi-g++]
-          build_type: "-msquic"
-        - arch: [mips, mips-linux-gnu-gcc, mips-linux-gnu-g++]
-          build_type: "-full"
         - arch: [riscv64, riscv64-linux-gnu-gcc, riscv64-linux-gnu-g++]
-          build_type: "-full"
-        - arch: [armel, arm-linux-gnueabi-gcc, arm-linux-gnueabi-g++]
           build_type: "-full"
 
     steps:
     - name: install toolchains
       run: |
-        sudo apt update
+        TARGET_ARCH="${{ matrix.arch[0] }}"
+        if [ "$TARGET_ARCH" = "x86_64" ]; then TARGET_ARCH="amd64"; fi
+
+        if [ "$TARGET_ARCH" != "amd64" ]; then
+          sudo dpkg --add-architecture $TARGET_ARCH
+
+          sudo sed -i 's/Types: deb/Types: deb\nArchitectures: amd64 i386/g' /etc/apt/sources.list.d/ubuntu.sources
+
+          echo "Types: deb
+        URIs: http://ports.ubuntu.com/ubuntu-ports/
+        Suites: noble noble-updates noble-backports
+        Components: main universe restricted multiverse
+        Architectures: arm64 armhf riscv64" | sudo tee /etc/apt/sources.list.d/ports.sources
+        fi
+
+        sudo apt-get update
+
         sudo chmod 755 /usr/local/bin
-        sudo apt install -y g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
-        sudo apt install -y g++-mips-linux-gnu gcc-mips-linux-gnu
-        sudo apt install -y g++-riscv64-linux-gnu gcc-riscv64-linux-gnu
-        sudo apt install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
-        sudo apt install -y gcc-arm-linux-gnueabi g++-arm-linux-gnueabi
-        sudo apt install -y cmake ninja-build rpm checkinstall
+
+        sudo apt-get install -y g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
+        sudo apt-get install -y g++-riscv64-linux-gnu gcc-riscv64-linux-gnu
+        sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+
+        sudo apt-get install -y cmake ninja-build rpm checkinstall pkg-config python3-pip
+        
         sudo sed -i 's/Version: ${VERSION}-${RELEASE}/Version: ${VERSION}/g' $(which checkinstall)
         sudo sed -i 's/-${RELEASE}_${ARCHITECTURE}/_${ARCHITECTURE}/g' $(which checkinstall)
-        sudo apt install -y pip
-        pip install Jinja2
-        
-        # 安装 pkg-config 和 dpkg-dev 以支持架构检测
-        sudo apt-get install -y pkg-config dpkg-dev
 
-        TARGET_ARCH="${{ matrix.arch[0] }}"
-        if [ "$TARGET_ARCH" = "amd64" ] || [ "$TARGET_ARCH" = "x86_64" ]; then
-            sudo apt-get install -y libssl-dev
-            
-            # 使用您提供的动态方式获取系统多架构路径前缀
-            HOST_MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
-            
-            # 建立软链接，移除 || true 以确保路径缺失时明确报错
-            sudo ln -sf "/usr/include/${HOST_MULTIARCH}/openssl/opensslconf.h" /usr/include/openssl/opensslconf.h
-            sudo ln -sf "/usr/include/${HOST_MULTIARCH}/openssl/configuration.h" /usr/include/openssl/configuration.h
+        python3 -m pip install Jinja2
+
+        if [ "$TARGET_ARCH" = "amd64" ]; then
+          sudo apt-get install -y libssl-dev
         else
-            echo "Cross-compiling for $TARGET_ARCH. Skipping native libssl-dev installation."
+          sudo apt-get install -y libssl-dev:$TARGET_ARCH
         fi
 
     - name: install mbed-tls
@@ -138,11 +134,6 @@ jobs:
         if [ "${{ github.event_name }}" == "release" ]; then
           LATEST_TAG="${{ github.ref_name }}"
         else
-          # Authenticate to avoid the anonymous rate limit shared by all
-          # Actions runners on this IP, which intermittently returns an error
-          # object that jq then fails to index as an array. The || true keeps
-          # a curl/jq failure on the explicit error path below instead of
-          # aborting the step via pipefail before it can report.
           LATEST_TAG="$(curl -fsS --retry 3 -H "Authorization: Bearer ${{ github.token }}" "https://api.github.com/repos/nanomq/nanomq/tags?per_page=1" | jq -r '.[0].name' || true)"
         fi
         if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" == "null" ]; then
@@ -176,11 +167,7 @@ jobs:
             make_flags+=" -DONEBRANCH=1 "
             make_flags+=" -DCMAKE_CROSSCOMPILING=ON "
             make_flags+=" -DCMAKE_PREFIX_PATH=${{ matrix.arch[4] }} "
-            # 引入 Sysroot 隔离墙，阻止 CMake 抓取宿主机 (x86_64) 的原生库与头文件
-            make_flags+=" -DCMAKE_FIND_ROOT_PATH=${{ matrix.arch[4] }} "
-            make_flags+=" -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY "
-            make_flags+=" -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY "
-            make_flags+=" -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ONLY "
+
             if [ "$arch" == "arm64" ]; then
               make_flags+=" -DCMAKE_TARGET_ARCHITECTURE=arm64 "
               make_flags+=" -DGNU_MACHINE=aarch64-linux-gnu "
@@ -207,7 +194,6 @@ jobs:
     - name: build
       run: |
         set -eu
-
         mkdir -p build
         cd build
         cmake ${{ steps.prepare.outputs.make_flags }} ..
@@ -356,7 +342,6 @@ jobs:
           token: ${{ github.token }}
           path: "source-with-submodules.tar.gz"
           ref: ${{ github.ref }}
-
 
   publish_packages:
     needs: [build_packages, build_docker]

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -63,7 +63,23 @@ jobs:
         sudo sed -i 's/-${RELEASE}_${ARCHITECTURE}/_${ARCHITECTURE}/g' $(which checkinstall)
         sudo apt install -y pip
         pip install Jinja2
-        sudo apt-get install pkg-config
+        
+        # 安装 pkg-config 和 dpkg-dev 以支持架构检测
+        sudo apt-get install -y pkg-config dpkg-dev
+
+        TARGET_ARCH="${{ matrix.arch[0] }}"
+        if [ "$TARGET_ARCH" = "amd64" ] || [ "$TARGET_ARCH" = "x86_64" ]; then
+            sudo apt-get install -y libssl-dev
+            
+            # 使用您提供的动态方式获取系统多架构路径前缀
+            HOST_MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+            
+            # 建立软链接，移除 || true 以确保路径缺失时明确报错
+            sudo ln -sf "/usr/include/${HOST_MULTIARCH}/openssl/opensslconf.h" /usr/include/openssl/opensslconf.h
+            sudo ln -sf "/usr/include/${HOST_MULTIARCH}/openssl/configuration.h" /usr/include/openssl/configuration.h
+        else
+            echo "Cross-compiling for $TARGET_ARCH. Skipping native libssl-dev installation."
+        fi
 
     - name: install mbed-tls
       run: |
@@ -160,6 +176,11 @@ jobs:
             make_flags+=" -DONEBRANCH=1 "
             make_flags+=" -DCMAKE_CROSSCOMPILING=ON "
             make_flags+=" -DCMAKE_PREFIX_PATH=${{ matrix.arch[4] }} "
+            # 引入 Sysroot 隔离墙，阻止 CMake 抓取宿主机 (x86_64) 的原生库与头文件
+            make_flags+=" -DCMAKE_FIND_ROOT_PATH=${{ matrix.arch[4] }} "
+            make_flags+=" -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY "
+            make_flags+=" -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY "
+            make_flags+=" -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ONLY "
             if [ "$arch" == "arm64" ]; then
               make_flags+=" -DCMAKE_TARGET_ARCHITECTURE=arm64 "
               make_flags+=" -DGNU_MACHINE=aarch64-linux-gnu "

--- a/etc/nanomq_example.conf
+++ b/etc/nanomq_example.conf
@@ -901,6 +901,12 @@ bridges.mqtt.emqx1 {
 			# # Value: String
 			# # Default: NULL
 			# suffix = ""
+
+			# # nolocal flag is used to prevents bridging client from receiving
+			# # messages that it has published itself. Only valid in MQTT V5
+			# # Value: bool
+			# # Default: true
+			# nolocal = true
 		}
 		{
 			remote_topic = "cmd/topic4"

--- a/etc/nanomq_example.conf
+++ b/etc/nanomq_example.conf
@@ -90,6 +90,14 @@ mqtt {
 	# # Hot updatable
 	# # Value: 1-infinity
 	property_size = 32
+
+	# # batch_resend
+	# # control the locale QoS msg resend rate.
+	# # Either in retry_interval rate or align with client's PUBACK
+	# #
+	# # Hot updatable
+	# # Value: true or false
+	batch_resend = false
 	
 }
 

--- a/nanomq/bridge.c
+++ b/nanomq/bridge.c
@@ -1150,7 +1150,8 @@ bridge_tcp_connect_cb(nng_pipe p, nng_pipe_ev ev, void *arg)
 		for (size_t i = 0; i < param->config->sub_count; i++) {
 			nng_mqtt_topic_qos_array_set(topic_qos, i,
 			    param->config->sub_list[i]->remote_topic,
-			    param->config->sub_list[i]->qos, 1,
+			    param->config->sub_list[i]->qos,
+				param->config->sub_list[i]->nolocal? 1:0,
 			    param->config->sub_list[i]->retain_as_published,
 			    param->config->sub_list[i]->retain_handling);
 			log_info("Bridge client subscribed topic %s (qos %d rap %d rh %d).",

--- a/nanomq/bridge.c
+++ b/nanomq/bridge.c
@@ -948,7 +948,8 @@ bridge_quic_connect_cb(nng_pipe p, nng_pipe_ev ev, void *arg)
 			    nng_mqtt_topic_qos_array_create(1);
 			nng_mqtt_topic_qos_array_set(topic_qos, 0,
 			    param->config->sub_list[i]->remote_topic,
-			    param->config->sub_list[i]->qos, 1,
+			    param->config->sub_list[i]->qos,
+				param->config->sub_list[i]->nolocal? 1:0,
 				param->config->sub_list[i]->retain_as_published,
 			    param->config->sub_list[i]->retain_handling);
 			log_info("Quic bridge client subscribe to "
@@ -1309,7 +1310,8 @@ bridge_tcp_reload(nng_socket *sock, conf *config, conf_bridge_node *node, bridge
 		for (size_t i = 0; i < bridge_arg->config->sub_count; i++) {
 			nng_mqtt_topic_qos_array_set(topic_qos, i,
 			    bridge_arg->config->sub_list[i]->remote_topic,
-			    bridge_arg->config->sub_list[i]->qos, 1,
+			    bridge_arg->config->sub_list[i]->qos,
+				bridge_arg->config->sub_list[i]->nolocal? 1:0,
 			    bridge_arg->config->sub_list[i]->retain_as_published,
 			    bridge_arg->config->sub_list[i]->retain_handling);
 			log_info("Bridge client subscribed topic %s (qos %d rap %d rh %d).",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved broker handling of client disconnects for more reliable message cleanup and immediate receive re-arming.
  - Added safer handling for unexpected/invalid message flags, including warnings and proper cleanup to prevent inconsistent dispatch behavior.

- **Maintenance**
  - Updated NanoMQ version metadata for the next release.
  - Refined cross-compilation and packaging to improve OpenSSL header resolution and CMake search behavior.
  - Updated the bundled networking component to a newer revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->