### PR TITLE
fix a memleak case in bridge reload

### DIFF
--- a/nanomq/bridge.c
+++ b/nanomq/bridge.c
@@ -165,8 +165,11 @@ create_connect_msg(conf_bridge_node *node)
 			nng_mqtt_msg_set_connect_will_property(
 			    connmsg, will_properties);
 		}
+		nng_mqttv5_msg_encode(connmsg);
+	} else if (node->proto_ver == MQTT_PROTOCOL_VERSION_v311){
+		nng_mqtt_msg_encode(connmsg);
 	}
-	nng_mqtt_msg_encode(connmsg);
+	
 	return connmsg;
 }
 

--- a/nanomq/bridge.c
+++ b/nanomq/bridge.c
@@ -166,6 +166,7 @@ create_connect_msg(conf_bridge_node *node)
 			    connmsg, will_properties);
 		}
 	}
+	nng_mqtt_msg_encode(connmsg);
 	return connmsg;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT connection message handling for both MQTT v5 and MQTT 3.1.1 connections.
  * Ensured connection messages are encoded using the correct protocol version before being sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->